### PR TITLE
Changes to Flod 4.1 as to be exported by ax3

### DIFF
--- a/Flod Flash/src/demos/Demo1.as
+++ b/Flod Flash/src/demos/Demo1.as
@@ -21,7 +21,7 @@
   formats, loaded from the client.
 
 */
-package {
+package demos {
   import flash.display.*;
   import flash.events.*;
   import flash.net.*;
@@ -29,12 +29,11 @@ package {
   import neoart.flod.core.*;
 
   public final class Demo1 extends Sprite {
-    private var
-      file   : FileReference,
-      loader : FileLoader,
-      player : CorePlayer;
+    private var  file   : FileReference;
+    private var   loader : FileLoader;
+    private var   player : CorePlayer;
 
-    public function Demo1() {
+    public function Demo1(stage:Stage) {
       loader = new FileLoader();
 
       stage.addEventListener(MouseEvent.CLICK, function(e:MouseEvent):void {
@@ -60,7 +59,10 @@ package {
     private function completeHandler(e:Event):void {
       file.removeEventListener(Event.COMPLETE, completeHandler);
       player = loader.load(file.data);
-      if (player && player.version) player.play();
+      if (player && player.version) {
+		  player.play();
+		  trace(player.toString());
+	  }
     }
   }
 }

--- a/Flod Flash/src/demos/Demo2.as
+++ b/Flod Flash/src/demos/Demo2.as
@@ -39,7 +39,7 @@
     STPlayer    Ultimate Soundtracker         neoart.flod.trackers
     DWPlayer    David Whittaker               neoart.flod.whittaker
 */
-package {
+package demos {
   import flash.display.*;
   import flash.events.*;
   import flash.net.*;
@@ -47,9 +47,8 @@ package {
   import neoart.flod.fasttracker.*;
 
   public final class Demo2 extends Sprite {
-    private var
-      file   : FileReference,
-      player : F2Player;
+    private var file   : FileReference;
+    private var  player : F2Player;
 
     public function Demo2() {
       player = new F2Player();

--- a/Flod Flash/src/demos/Demo3.as
+++ b/Flod Flash/src/demos/Demo3.as
@@ -21,19 +21,18 @@
   formats, with an embedded module.
 
 */
-package {
+package demos {
   import flash.display.*;
   import flash.utils.*;
   import neoart.flod.*;
   import neoart.flod.core.*;
 
   public final class Demo3 extends Sprite {
-    [Embed(source="filename.mod", mimeType="application/octet-stream")]
+    //[Embed(source="filename.mod", mimeType="application/octet-stream")]
 
-    private var
-      Song   : Class,
-      loader : FileLoader,
-      player : CorePlayer;
+    private var Song   : Class;
+    private var loader : FileLoader;
+    private var player : CorePlayer;
 
     public function Demo3() {
       loader = new FileLoader();

--- a/Flod Flash/src/demos/Demo4.as
+++ b/Flod Flash/src/demos/Demo4.as
@@ -39,7 +39,7 @@
     STPlayer    Ultimate Soundtracker         neoart.flod.trackers
     DWPlayer    David Whittaker               neoart.flod.whittaker
 */
-package {
+package demos {
   import flash.display.*;
   import flash.events.*;
   import flash.utils.*;
@@ -47,11 +47,10 @@ package {
   import neoart.flod.fred.*;
 
   public final class Demo4 extends Sprite {
-    [Embed(source="filename.mod", mimeType="application/octet-stream")]
+    //[Embed(source="filename.mod", mimeType="application/octet-stream")]
 
-    private var
-      Song   : Class,
-      player : FEPlayer;
+    private var   Song   : Class;
+    private var  player : FEPlayer;
 
     public function Demo4() {
       player = new FEPlayer();

--- a/Flod Flash/src/demos/Demo5.as
+++ b/Flod Flash/src/demos/Demo5.as
@@ -23,7 +23,7 @@
   Warning: the server must be able to handle the correct file extension, if it can't just rename the file
   to filename.wav and it should work...
 */
-package {
+package demos {
   import flash.display.*;
   import flash.events.*;
   import flash.net.*;
@@ -31,10 +31,9 @@ package {
   import neoart.flod.core.*;
 
   public final class Demo5 extends Sprite {
-    private var
-      url    : URLLoader,
-      loader : FileLoader,
-      player : CorePlayer;
+    private var   url    : URLLoader;
+     private var  loader : FileLoader;
+     private var  player : CorePlayer;
 
     public function Demo5() {
       loader = new FileLoader();

--- a/Flod Flash/src/demos/Demo6.as
+++ b/Flod Flash/src/demos/Demo6.as
@@ -39,7 +39,7 @@
     STPlayer    Ultimate Soundtracker         neoart.flod.trackers
     DWPlayer    David Whittaker               neoart.flod.whittaker
 */
-package {
+package demos {
   import flash.display.*;
   import flash.events.*;
   import flash.net.*;
@@ -47,9 +47,8 @@ package {
   import neoart.flod.sidmon.*;
 
   public final class Demo6 extends Sprite {
-    private var
-      url    : URLLoader,
-      player : S1Player;
+    private var   url    : URLLoader;
+     private var  player : S1Player;
 
     public function Demo6() {
       player = new S1Player();

--- a/Flod Flash/src/neoart/flip/Huffman.as
+++ b/Flod Flash/src/neoart/flip/Huffman.as
@@ -16,9 +16,8 @@
 package neoart.flip {
 
   public final class Huffman {
-    internal var
-      count  : Vector.<int>,
-      symbol : Vector.<int>;
+    internal var  count  : Vector.<int>;
+    internal var  symbol : Vector.<int>;
 
     public function Huffman(length:int) {
       count  = new Vector.<int>(length, true);

--- a/Flod Flash/src/neoart/flip/Inflater.as
+++ b/Flod Flash/src/neoart/flip/Inflater.as
@@ -17,18 +17,17 @@ package neoart.flip {
   import flash.utils.*;
 
   public final class Inflater {
-    internal var
-      output   : ByteArray;
-    private var
-      inpbuf   : ByteArray,
-      inpcnt   : int,
-      outcnt   : int,
-      bitbuf   : int,
-      bitcnt   : int,
-      flencode : Huffman,
-      fdiscode : Huffman,
-      dlencode : Huffman,
-      ddiscode : Huffman;
+    internal var  output   : ByteArray;
+	
+    private var  inpbuf   : ByteArray;
+    private var  inpcnt   : int;
+    private var  outcnt   : int;
+    private var  bitbuf   : int;
+    private var  bitcnt   : int;
+    private var   flencode : Huffman;
+    private var  fdiscode : Huffman;
+    private var  dlencode : Huffman;
+    private var ddiscode : Huffman;
 
     public function Inflater() {
       initialize();
@@ -230,23 +229,23 @@ package neoart.flip {
       return codes(dlencode, ddiscode);
     }
 
-    private static const
-      ERROR1   : String = "Invalid block type.",
-      ERROR2   : String = "Available inflate data did not terminate.",
-      ERROR3   : String = "Invalid literal/length or distance code.",
-      ERROR4   : String = "Distance is too far back.",
-      ERROR5   : String = "Stored block length did not match one's complement.",
-      ERROR6   : String = "Too many length or distance codes.",
-      ERROR7   : String = "Code lengths codes incomplete.",
-      ERROR8   : String = "Repeat lengths with no first length.",
-      ERROR9   : String = "Repeat more than specified lengths.",
-      ERROR10  : String = "Invalid literal/length code lengths.",
-      ERROR11  : String = "Invalid distance code lengths.",
+    
+     private static const ERROR1   : String = "Invalid block type.";
+     private static const ERROR2   : String = "Available inflate data did not terminate.";
+     private static const ERROR3   : String = "Invalid literal/length or distance code.";
+     private static const ERROR4   : String = "Distance is too far back.";
+     private static const ERROR5   : String = "Stored block length did not match one's complement.";
+     private static const ERROR6   : String = "Too many length or distance codes.";
+     private static const ERROR7   : String = "Code lengths codes incomplete.";
+     private static const ERROR8   : String = "Repeat lengths with no first length.";
+     private static const ERROR9   : String = "Repeat more than specified lengths.";
+     private static const ERROR10  : String = "Invalid literal/length code lengths.";
+     private static const ERROR11  : String = "Invalid distance code lengths.";
 
-      LENG  : Vector.<int> = Vector.<int>([3,4,5,6,7,8,9,10,11,13,15,17,19,23,27,31,35,43,51,59,67,83,99,115,131,163,195,227,258]),
-      LEXT  : Vector.<int> = Vector.<int>([0,0,0,0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,4,4,4,4,5,5,5,5,0]),
-      DIST  : Vector.<int> = Vector.<int>([1,2,3,4,5,7,9,13,17,25,33,49,65,97,129,193,257,385,513,769,1025,1537,2049,3073,4097,6145,8193,12289,16385,24577]),
-      DEXT  : Vector.<int> = Vector.<int>([0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,11,12,12,13,13]),
-      ORDER : Vector.<int> = Vector.<int>([16,17,18,0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15]);
+     private static const LENG  : Vector.<int> = Vector.<int>([3,4,5,6,7,8,9,10,11,13,15,17,19,23,27,31,35,43,51,59,67,83,99,115,131,163,195,227,258]);
+     private static const LEXT  : Vector.<int> = Vector.<int>([0,0,0,0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,4,4,4,4,5,5,5,5,0]);
+     private static const DIST  : Vector.<int> = Vector.<int>([1,2,3,4,5,7,9,13,17,25,33,49,65,97,129,193,257,385,513,769,1025,1537,2049,3073,4097,6145,8193,12289,16385,24577]);
+     private static const DEXT  : Vector.<int> = Vector.<int>([0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,11,12,12,13,13]);
+     private static const ORDER : Vector.<int> = Vector.<int>([16,17,18,0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15]);
   }
 }

--- a/Flod Flash/src/neoart/flip/ZipEntry.as
+++ b/Flod Flash/src/neoart/flip/ZipEntry.as
@@ -17,17 +17,17 @@ package neoart.flip {
   import flash.utils.*;
 
   public final class ZipEntry {
-    public var
-      name       : String,
-      extra      : ByteArray,
-      version    : int,
-      flag       : int,
-      method     : int,
-      time       : uint,
-      crc        : uint,
-      compressed : uint,
-      size       : uint,
-      offset     : uint;
+    
+    public var  name       : String;
+    public var  extra      : ByteArray;
+    public var  version    : int;
+    public var  flag       : int;
+    public var method     : int;
+    public var  time       : uint;
+    public var  crc        : uint;
+    public var  compressed : uint;
+    public var  size       : uint;
+    public var offset     : uint;
 
     public function get date():Date {
       return new Date(

--- a/Flod Flash/src/neoart/flip/ZipFile.as
+++ b/Flod Flash/src/neoart/flip/ZipFile.as
@@ -126,10 +126,9 @@ package neoart.flip {
       parseCentral();
     }
 
-    private static const
-      ERROR1 : String = "The archive is either in unknown format or damaged.",
-      ERROR2 : String = "Unexpected end of archive.",
-      ERROR3 : String = "Encrypted archive not supported.",
-      ERROR4 : String = "Compression method not supported.";
+    private static const ERROR1 : String = "The archive is either in unknown format or damaged.";
+    private static const ERROR2 : String = "Unexpected end of archive.";
+    private static const ERROR3 : String = "Encrypted archive not supported.";
+    private static const ERROR4 : String = "Compression method not supported.";
   }
 }

--- a/Flod Flash/src/neoart/flod/FileLoader.as
+++ b/Flod Flash/src/neoart/flod/FileLoader.as
@@ -33,11 +33,11 @@ package neoart.flod {
   import neoart.flod.whittaker.*;
 
   public final class FileLoader {
-    private var
-      player : CorePlayer,
-      index  : int,
-      amiga  : Amiga,
-      mixer  : Soundblaster;
+    
+    private var player : CorePlayer;
+    private var index  : int;
+    private var amiga  : Amiga;
+    private var mixer  : Soundblaster;
 
     public function FileLoader() {
       amiga = new Amiga();
@@ -317,24 +317,24 @@ package neoart.flod {
       return player = null;
     }
 
-    private static const
-      SOUNDTRACKER = 0,
-      NOISETRACKER = 4,
-      PROTRACKER   = 9,
-      HISMASTER    = 12,
-      SOUNDFX      = 13,
-      BPSOUNDMON   = 17,
-      DELTAMUSIC   = 20,
-      DIGITALMUG   = 22,
-      FUTURECOMP   = 24,
-      SIDMON       = 26,
-      WHITTAKER    = 28,
-      FREDED       = 29,
-      HIPPEL       = 30,
-      HUBBARD      = 32,
-      FASTTRACKER  = 33,
+    
+     private static const SOUNDTRACKER :int = 0;
+     private static const NOISETRACKER :int = 4;
+     private static const PROTRACKER:int   = 9;
+     private static const HISMASTER :int   = 12;
+     private static const SOUNDFX  :int    = 13;
+     private static const BPSOUNDMON :int  = 17;
+     private static const DELTAMUSIC :int  = 20;
+     private static const DIGITALMUG :int  = 22;
+     private static const FUTURECOMP :int  = 24;
+     private static const SIDMON    :int   = 26;
+     private static const WHITTAKER :int   = 28;
+     private static const FREDED    :int   = 29;
+     private static const HIPPEL    :int   = 30;
+     private static const HUBBARD    :int  = 32;
+     private static const FASTTRACKER:int  = 33;
 
-      TRACKERS = [
+      private static const TRACKERS : Vector.<String> = Vector.<String> ([
         "Unknown Format",
         "Ultimate SoundTracker",
         "D.O.C. SoundTracker 9",
@@ -374,6 +374,6 @@ package neoart.flod {
         "MadTracker 2.0",
         "MilkyTracker",
         "DigiBooster Pro 2.18",
-        "OpenMPT"];
+        "OpenMPT"]);
   }
 }

--- a/Flod Flash/src/neoart/flod/core/Amiga.as
+++ b/Flod Flash/src/neoart/flod/core/Amiga.as
@@ -20,19 +20,19 @@ package neoart.flod.core {
   import flash.utils.*;
 
   public final class Amiga extends CoreMixer {
-    public static const
-      MODEL_A500  : int = 0,
-      MODEL_A1200 : int = 1;
-    public var
-      filter   : AmigaFilter,
-      model    : int = MODEL_A1200,
-      memory   : Vector.<int>,
-      channels : Vector.<AmigaChannel>,
-      loopPtr  : int,
-      loopLen  : int = 4;
-    internal var
-      clock    : Number = 0.0,
-      master   : Number = 0.00390625;
+
+    public static const  MODEL_A500  : int = 0;
+    public static const  MODEL_A1200 : int = 1;
+    
+    public var  filter   : AmigaFilter;
+    public var  model    : int = MODEL_A1200;
+    public var  memory   : Vector.<int>;
+    public var  channels : Vector.<AmigaChannel>;
+    public var  loopPtr  : int;
+    public var  loopLen  : int = 4;
+    
+    internal var  clock    : Number = 0.0;
+    internal var  master   : Number = 0.00390625;
 
     public function Amiga() {
       super();

--- a/Flod Flash/src/neoart/flod/core/AmigaChannel.as
+++ b/Flod Flash/src/neoart/flod/core/AmigaChannel.as
@@ -18,23 +18,23 @@
 package neoart.flod.core {
 
   public final class AmigaChannel {
-    public var
-      next    : AmigaChannel,
-      mute    : int,
-      panning : Number = 1.0,
-      delay   : int,
-      pointer : int,
-      length  : int;
-    internal var
-      audena  : int,
-      audcnt  : int,
-      audloc  : int,
-      audper  : int,
-      audvol  : int,
-      timer   : Number,
-      level   : Number,
-      ldata   : Number,
-      rdata   : Number;
+    
+     public var next    : AmigaChannel;
+     public var mute    : int;
+     public var panning : Number = 1.0;
+     public var delay   : int;
+     public var pointer : int;
+     public var length  : int;
+   
+      internal var audena  : int;
+      internal var audcnt  : int;
+      internal var audloc  : int;
+      internal var audper  : int;
+      internal var audvol  : int;
+      internal var timer   : Number;
+      internal var level   : Number;
+      internal var ldata   : Number;
+      internal var rdata   : Number;
 
     public function AmigaChannel(index:int) {
       if ((++index & 2) == 0) panning = -panning;
@@ -55,15 +55,23 @@ package neoart.flod.core {
     }
 
     public function set period(value:int):void {
-      if (value < 0) value = 0;
-        else if(value > 65535) value = 65535;
+      if (value < 0) {
+		value = 0;
+	  }
+        else if (value > 65535) {
+			value = 65535;
+		}
 
       audper = value;
     }
 
     public function set volume(value:int):void {
-      if (value < 0) value = 0;
-        else if (value > 64) value = 64;
+      if (value < 0) {
+	  value = 0;
+	  }
+        else if (value > 64) {
+			value = 64;
+		}
 
       audvol = value;
     }

--- a/Flod Flash/src/neoart/flod/core/AmigaFilter.as
+++ b/Flod Flash/src/neoart/flod/core/AmigaFilter.as
@@ -18,24 +18,24 @@
 package neoart.flod.core {
 
   public final class AmigaFilter {
-    public static const
-      AUTOMATIC : int =  0,
-      FORCE_ON  : int =  1,
-      FORCE_OFF : int = -1;
-    public var
-      active    : int,
-      forced    : int = FORCE_OFF;
-    private var
-      l0        : Number,
-      l1        : Number,
-      l2        : Number,
-      l3        : Number,
-      l4        : Number,
-      r0        : Number,
-      r1        : Number,
-      r2        : Number,
-      r3        : Number,
-      r4        : Number;
+    
+    public static const  AUTOMATIC : int =  0;
+    public static const  FORCE_ON  : int =  1;
+    public static const  FORCE_OFF : int = -1;
+   
+     public var  active    : int;
+     public var  forced    : int = FORCE_OFF;
+   
+      private var l0        : Number;
+      private var l1        : Number;
+      private var l2        : Number;
+     private var  l3        : Number;
+     private var  l4        : Number;
+      private var r0        : Number;
+      private var r1        : Number;
+      private var r2        : Number;
+      private var r3        : Number;
+      private var r4        : Number;
 
     internal function initialize():void {
       l0 = l1 = l2 = l3 = l4 = 0.0;
@@ -43,11 +43,16 @@ package neoart.flod.core {
     }
 
     internal function process(model:int, sample:Sample):void {
-      var FL:Number = 0.5213345843532200, P0:Number = 0.4860348337215757, P1:Number = 0.9314955486749749, d:Number = 1.0 - P0;
+      var FL:Number = 0.5213345843532200;
+	  var P0:Number = 0.4860348337215757;
+	  var P1:Number = 0.9314955486749749; 
+	  var d:Number = 1.0 - P0;
 
-      if (model == 0) {
-        l0 = P0 * sample.l + d * l0 + 1e-18 - 1e-18;
-        r0 = P0 * sample.r + d * r0 + 1e-18 - 1e-18;
+      if (model == 0) 
+	  {
+
+        l0 = P0 * sample.l + d * l0 + 1.0e-18 - 1.0e-18;
+        r0 = P0 * sample.r + d * r0 + 1.0e-18 - 1.0e-18;
         d = 1 - P1;
         sample.l = l1 = P1 * l0 + d * l1;
         sample.r = r1 = P1 * r0 + d * r1;
@@ -55,19 +60,25 @@ package neoart.flod.core {
 
       if ((active | forced) > 0) {
         d = 1 - FL;
-        l2 = FL * sample.l + d * l2 + 1e-18 - 1e-18;
-        r2 = FL * sample.r + d * r2 + 1e-18 - 1e-18;
+        l2 = FL * sample.l + d * l2 + 1.0e-18 - 1.0e-18;
+        r2 = FL * sample.r + d * r2 + 1.0e-18 - 1.0e-18;
         l3 = FL * l2 + d * l3;
         r3 = FL * r2 + d * r3;
         sample.l = l4 = FL * l3 + d * l4;
         sample.r = r4 = FL * r3 + d * r4;
       }
 
-      if (sample.l > 1.0) sample.l = 1.0;
-        else if (sample.l < -1.0) sample.l = -1.0;
+      if (sample.l > 1.0) {sample.l = 1.0;}
+        else if (sample.l < -1.0) {
+			sample.l = -1.0;
+		}
 
-      if (sample.r > 1.0) sample.r = 1.0;
-        else if (sample.r < -1.0) sample.r = -1.0;
+      if (sample.r > 1.0) {
+		  sample.r = 1.0;
+	  }
+        else if (sample.r < -1.0) {
+			sample.r = -1.0;
+		}
     }
   }
 }

--- a/Flod Flash/src/neoart/flod/core/AmigaPlayer.as
+++ b/Flod Flash/src/neoart/flod/core/AmigaPlayer.as
@@ -18,10 +18,8 @@
 package neoart.flod.core {
 
   public class AmigaPlayer extends CorePlayer {
-    public var
-      amiga    : Amiga;
-    protected var
-      standard : int;
+    public var amiga    : Amiga;
+    protected var standard : int;
 
     public function AmigaPlayer(amiga:Amiga) {
       this.amiga = amiga || new Amiga();
@@ -49,8 +47,12 @@ package neoart.flod.core {
     override public function set stereo(value:Number):void {
       var chan:AmigaChannel = amiga.channels[0];
 
-      if (value < 0.0) value = 0.0;
-        else if (value > 1.0) value = 1.0;
+      if (value < 0.0) {
+		  value = 0.0;
+	  }
+        else if (value > 1.0) {
+			value = 1.0;
+		}
 
       while (chan) {
         chan.level = value * chan.panning;
@@ -59,8 +61,12 @@ package neoart.flod.core {
     }
 
     override public function set volume(value:Number):void {
-      if (value < 0.0) value = 0.0;
-        else if (value > 1.0) value = 1.0;
+      if (value < 0.0) {
+	  value = 0.0; }
+	  
+        else if (value > 1.0) {
+			value = 1.0;
+		}
 
       amiga.master = value * 0.00390625;
     }

--- a/Flod Flash/src/neoart/flod/core/AmigaRow.as
+++ b/Flod Flash/src/neoart/flod/core/AmigaRow.as
@@ -18,10 +18,9 @@
 package neoart.flod.core {
 
   public class AmigaRow {
-    public var
-      note   : int,
-      sample : int,
-      effect : int,
-      param  : int;
+    public var note   : int;
+    public var sample : int;
+    public var effect : int;
+    public var param  : int;
   }
 }

--- a/Flod Flash/src/neoart/flod/core/AmigaSample.as
+++ b/Flod Flash/src/neoart/flod/core/AmigaSample.as
@@ -18,13 +18,13 @@
 package neoart.flod.core {
 
   public class AmigaSample {
-    public var
-      name    : String = "",
-      length  : int,
-      loop    : int,
-      repeat  : int,
-      volume  : int,
-      pointer : int,
-      loopPtr : int;
+    
+    public var name    : String = "";
+    public var length  : int;
+    public var loop    : int;
+    public var repeat  : int;
+    public var volume  : int;
+    public var pointer : int;
+    public var loopPtr : int;
   }
 }

--- a/Flod Flash/src/neoart/flod/core/AmigaStep.as
+++ b/Flod Flash/src/neoart/flod/core/AmigaStep.as
@@ -18,8 +18,8 @@
 package neoart.flod.core {
 
   public class AmigaStep {
-    public var
-      pattern   : int,
-      transpose : int;
+    
+    public var pattern   : int;
+    public var transpose : int;
   }
 }

--- a/Flod Flash/src/neoart/flod/core/CoreMixer.as
+++ b/Flod Flash/src/neoart/flod/core/CoreMixer.as
@@ -20,15 +20,15 @@ package neoart.flod.core {
   import flash.utils.*;
 
   public class CoreMixer {
-    public var
-      player      : CorePlayer,
-      samplesTick : int;
-    protected var
-      buffer      : Vector.<Sample>,
-      samplesLeft : int,
-      remains     : int,
-      completed   : int,
-      wave        : ByteArray;
+    
+    public var player      : CorePlayer;
+    public var samplesTick : int;
+    
+    protected var buffer      : Vector.<Sample>;
+    protected var samplesLeft : int;
+    protected var remains     : int;
+    protected var completed   : int;
+    protected var wave        : ByteArray;
 
     public function CoreMixer() {
       wave = new ByteArray();

--- a/Flod Flash/src/neoart/flod/core/CorePlayer.as
+++ b/Flod Flash/src/neoart/flod/core/CorePlayer.as
@@ -22,27 +22,27 @@ package neoart.flod.core {
   import neoart.flip.*;
 
   public class CorePlayer extends EventDispatcher {
-    public static const
-      ENCODING : String = "us-ascii";
-    public var
-      quality   : int,
-      record    : int,
-      playSong  : int,
-      lastSong  : int,
-      version   : int,
-      variant   : int,
-      title     : String = "",
-      channels  : int,
-      loopSong  : int,
-      speed     : int,
-      tempo     : int;
-    protected var
-      hardware  : CoreMixer,
-      sound     : Sound,
-      soundChan : SoundChannel,
-      soundPos  : Number = 0.0,
-      endian    : String,
-      tick      : int;
+    
+    public static const ENCODING : String = "us-ascii";
+    
+    public var quality   : int;
+    public var record    : int;
+    public var playSong  : int;
+    public var lastSong  : int;
+    public var version   : int;
+    public var variant   : int;
+    public var title     : String = "";
+    public var channels  : int;
+    public var loopSong  : int;
+    public var speed     : int;
+    public var tempo     : int;
+    
+    protected var hardware  : CoreMixer;
+    protected var sound     : Sound;
+    protected var soundChan : SoundChannel;
+    protected var soundPos  : Number = 0.0;
+    protected var endian    : String;
+    protected var tick      : int;
 
     public function CorePlayer(hardware:CoreMixer) {
       hardware.player = this;

--- a/Flod Flash/src/neoart/flod/core/SBChannel.as
+++ b/Flod Flash/src/neoart/flod/core/SBChannel.as
@@ -18,47 +18,47 @@
 package neoart.flod.core {
 
   public final class SBChannel {
-    public var
-      next        : SBChannel,
-      mute        : int,
-      enabled     : int,
-      sample      : SBSample,
-      length      : int,
-      index       : int,
-      pointer     : int,
-      delta       : int,
-      fraction    : Number,
-      speed       : Number,
-      dir         : int,
-      oldSample   : SBSample,
-      oldLength   : int,
-      oldPointer  : int,
-      oldFraction : Number,
-      oldSpeed    : Number,
-      oldDir      : int,
-      volume      : Number,
-      lvol        : Number,
-      rvol        : Number,
-      panning     : int,
-      lpan        : Number,
-      rpan        : Number,
-      ldata       : Number,
-      rdata       : Number,
-      mixCounter  : int,
-      lmixRampU   : Number,
-      lmixDeltaU  : Number,
-      rmixRampU   : Number,
-      rmixDeltaU  : Number,
-      lmixRampD   : Number,
-      lmixDeltaD  : Number,
-      rmixRampD   : Number,
-      rmixDeltaD  : Number,
-      volCounter  : int,
-      lvolDelta   : Number,
-      rvolDelta   : Number,
-      panCounter  : int,
-      lpanDelta   : Number,
-      rpanDelta   : Number;
+    
+    public var next        : SBChannel;
+    public var mute        : int;
+    public var enabled     : int;
+    public var sample      : SBSample;
+    public var length      : int;
+    public var index       : int;
+    public var pointer     : int;
+    public var delta       : int;
+    public var fraction    : Number;
+    public var speed       : Number;
+    public var dir         : int;
+    public var oldSample   : SBSample;
+    public var oldLength   : int;
+    public var oldPointer  : int;
+    public var oldFraction : Number;
+    public var oldSpeed    : Number;
+    public var oldDir      : int;
+    public var volume      : Number;
+    public var lvol        : Number;
+    public var rvol        : Number;
+    public var panning     : int;
+    public var lpan        : Number;
+    public var rpan        : Number;
+    public var ldata       : Number;
+    public var rdata       : Number;
+    public var mixCounter  : int;
+    public var lmixRampU   : Number;
+    public var lmixDeltaU  : Number;
+    public var rmixRampU   : Number;
+    public var rmixDeltaU  : Number;
+    public var lmixRampD   : Number;
+    public var lmixDeltaD  : Number;
+    public var rmixRampD   : Number;
+    public var rmixDeltaD  : Number;
+    public var volCounter  : int;
+    public var lvolDelta   : Number;
+    public var rvolDelta   : Number;
+    public var panCounter  : int;
+    public var lpanDelta   : Number;
+    public var rpanDelta   : Number;
 
     internal function initialize():void {
       enabled     = 0;
@@ -79,7 +79,7 @@ package neoart.flod.core {
       volume      = 0.0;
       lvol        = 0.0;
       rvol        = 0.0;
-      panning     = 128
+      panning     = 128;
       lpan        = 0.5;
       rpan        = 0.5;
       ldata       = 0.0;

--- a/Flod Flash/src/neoart/flod/core/SBPlayer.as
+++ b/Flod Flash/src/neoart/flod/core/SBPlayer.as
@@ -18,14 +18,14 @@
 package neoart.flod.core {
 
   public class SBPlayer extends CorePlayer {
-    public var
-      mixer   : Soundblaster,
-      length  : int,
-      restart : int,
-      track   : Vector.<int>;
-    protected var
-      timer   : int,
-      master  : int;
+    
+    public var mixer   : Soundblaster;
+    public var length  : int;
+    public var restart : int;
+    public var track   : Vector.<int>;
+    
+    protected var timer   : int;
+    protected var master  : int;
 
     public function SBPlayer(mixer:Soundblaster = null) {
       this.mixer = mixer || new Soundblaster();
@@ -36,8 +36,11 @@ package neoart.flod.core {
   }
 
     override public function set volume(value:Number):void {
-      if (value < 0.0) value = 0.0;
-        else if (value > 1.0) value = 1.0;
+      if (value < 0.0) {
+	  value = 0.0;}
+        else if (value > 1.0) {
+			value = 1.0;
+		}
 
       master = value * 64;
     }
@@ -50,7 +53,8 @@ package neoart.flod.core {
       mixer.setup(channels);
     }
 
-    override protected function initialize():void {
+    override protected function initialize():void 
+	{
       super.initialize();
       timer  = speed;
       master = 64;

--- a/Flod Flash/src/neoart/flod/core/SBSample.as
+++ b/Flod Flash/src/neoart/flod/core/SBSample.as
@@ -19,15 +19,15 @@ package neoart.flod.core {
   import flash.utils.*;
 
   public class SBSample {
-    public var
-      name      : String = "",
-      bits      : int = 8,
-      volume    : int,
-      length    : int,
-      data      : Vector.<Number>,
-      loopMode  : int,
-      loopStart : int,
-      loopLen   : int;
+    
+    public var name      : String = "";
+    public var bits      : int = 8;
+    public var volume    : int;
+    public var length    : int;
+    public var data      : Vector.<Number>;
+    public var loopMode  : int;
+    public var loopStart : int;
+    public var loopLen   : int;
 
     public function store(stream:ByteArray):void {
       var delta:int, i:int, len:int = length, pos:int, sample:Number, total:int, value:int;
@@ -45,13 +45,19 @@ package neoart.flod.core {
         total = pos + len;
 
         if (total > stream.length)
-          len = stream.length - pos;
+          {
+			  len = stream.length - pos;
+		  }
 
         for (i = 0; i < len; ++i) {
           value = stream.readByte() + delta;
 
-          if (value < -128) value += 256;
-            else if (value > 127) value -= 256;
+          if (value < -128) {
+			  value += 256;
+		  }
+            else if (value > 127) {
+				value -= 256;
+			}
 
           data[i] = value * 0.0078125;
           delta = value;
@@ -65,8 +71,12 @@ package neoart.flod.core {
         for (i = 0; i < len; ++i) {
           value = stream.readShort() + delta;
 
-          if (value < -32768) value += 65536;
-            else if (value > 32767) value -= 65536;
+          if (value < -32768) {
+		  value += 65536;
+		  }
+            else if (value > 32767) {
+				value -= 65536;
+			}
 
           data[i] = value * 0.00003051758;
           delta = value;
@@ -89,11 +99,16 @@ package neoart.flod.core {
 
       if (len != length) {
         sample = data[int(len - 1)];
-        for (i = len; i < length; ++i) data[i] = sample;
+        for (i = len; i < length; ++i) {
+			data[i] = sample;
+		}
       }
 
-      if (total < stream.length) stream.position = total;
-        else stream.position = stream.length - 1;
+      if (total < stream.length) {
+	  stream.position = total;}
+        else {
+			stream.position = stream.length - 1;
+		}
     }
   }
 }

--- a/Flod Flash/src/neoart/flod/core/Sample.as
+++ b/Flod Flash/src/neoart/flod/core/Sample.as
@@ -18,9 +18,9 @@
 package neoart.flod.core {
 
   public final class Sample {
-    public var
-      l    : Number = 0.0,
-      r    : Number = 0.0,
-      next : Sample;
+    
+     public var l    : Number = 0.0;
+     public var r    : Number = 0.0;
+     public var next : Sample;
   }
 }

--- a/Flod Flash/src/neoart/flod/core/Soundblaster.as
+++ b/Flod Flash/src/neoart/flod/core/Soundblaster.as
@@ -106,8 +106,12 @@ package neoart.flod.core {
               } else chan.pointer = chan.index;
 
               if (!chan.mute) {
-                if (!chan.dir) value = d[chan.pointer];
-                  else value = d[int(chan.dir - chan.pointer)];
+                if (!chan.dir) {
+					value = d[chan.pointer];
+				}
+                  else {
+					  value = d[int(chan.dir - chan.pointer)];
+				  }
 
                 chan.ldata = value * chan.lvol;
                 chan.rdata = value * chan.rvol;
@@ -140,11 +144,19 @@ package neoart.flod.core {
 
       if (player.record) {
         for (i = 0; i < size; ++i) {
-          if (sample.l > 1.0) sample.l = 1.0;
-            else if (sample.l < -1.0) sample.l = -1.0;
+          if (sample.l > 1.0) {
+		  sample.l = 1.0;
+		  
+		  }
+            else if (sample.l < -1.0) {
+				sample.l = -1.0;
+			}
 
-          if (sample.r > 1.0) sample.r = 1.0;
-            else if (sample.r < -1.0) sample.r = -1.0;
+          if (sample.r > 1.0) {
+		  sample.r = 1.0;}
+            else if (sample.r < -1.0) {
+				sample.r = -1.0;
+			}
 
           wave.writeShort(int(sample.l * (sample.l < 0 ? 32768 : 32767)));
           wave.writeShort(int(sample.r * (sample.r < 0 ? 32768 : 32767)));
@@ -157,11 +169,21 @@ package neoart.flod.core {
         }
       } else {
         for (i = 0; i < size; ++i) {
-          if (sample.l > 1.0) sample.l = 1.0;
-            else if (sample.l < -1.0) sample.l = -1.0;
+          if (sample.l > 1.0) {
+		  sample.l = 1.0;
+		  
+			}
+            else if (sample.l < -1.0) {
+				sample.l = -1.0;
+			}
 
-          if (sample.r > 1.0) sample.r = 1.0;
-            else if (sample.r < -1.0) sample.r = -1.0;
+          if (sample.r > 1.0) {
+		  sample.r = 1.0;
+		  
+		  }
+            else if (sample.r < -1.0) {
+				sample.r = -1.0;
+			}
 
           data.writeFloat(sample.l);
           data.writeFloat(sample.r);
@@ -351,11 +373,20 @@ package neoart.flod.core {
 
       if (player.record) {
         for (i = 0; i < size; ++i) {
-          if (sample.l > 1.0) sample.l = 1.0;
-            else if (sample.l < -1.0) sample.l = -1.0;
+          if (sample.l > 1.0) {
+		  sample.l = 1.0;
+		  
+		  }
+            else if (sample.l < -1.0) {
+				sample.l = -1.0;
+			}
 
-          if (sample.r > 1.0) sample.r = 1.0;
-            else if (sample.r < -1.0) sample.r = -1.0;
+          if (sample.r > 1.0) {
+			  sample.r = 1.0;
+		  }
+            else if (sample.r < -1.0) {
+				sample.r = -1.0;
+			}
 
           wave.writeShort(int(sample.l * (sample.l < 0 ? 32768 : 32767)));
           wave.writeShort(int(sample.r * (sample.r < 0 ? 32768 : 32767)));
@@ -368,11 +399,17 @@ package neoart.flod.core {
         }
       } else {
         for (i = 0; i < size; ++i) {
-          if (sample.l > 1.0) sample.l = 1.0;
-            else if (sample.l < -1.0) sample.l = -1.0;
+          if (sample.l > 1.0){
+		  sample.l = 1.0;}
+            else if (sample.l < -1.0) {
+				sample.l = -1.0;
+			}
 
-          if (sample.r > 1.0) sample.r = 1.0;
-            else if (sample.r < -1.0) sample.r = -1.0;
+          if (sample.r > 1.0) {
+		  sample.r = 1.0;}
+            else if (sample.r < -1.0) {
+				sample.r = -1.0;
+			}
 
           data.writeFloat(sample.l);
           data.writeFloat(sample.r);

--- a/Flod Flash/src/neoart/flod/deltamusic/D1Player.as
+++ b/Flod Flash/src/neoart/flod/deltamusic/D1Player.as
@@ -20,12 +20,12 @@ package neoart.flod.deltamusic {
   import neoart.flod.core.*;
 
   public final class D1Player extends AmigaPlayer {
-    private var
-      pointers : Vector.<int>,
-      tracks   : Vector.<AmigaStep>,
-      patterns : Vector.<AmigaRow>,
-      samples  : Vector.<D1Sample>,
-      voices   : Vector.<D1Voice>;
+    
+    private var pointers : Vector.<int>;
+    private var tracks   : Vector.<AmigaStep>;
+    private var patterns : Vector.<AmigaRow>;
+    private var samples  : Vector.<D1Sample>;
+    private var voices   : Vector.<D1Voice>;
 
     public function D1Player(amiga:Amiga = null) {
       super(amiga);
@@ -135,8 +135,12 @@ package neoart.flod.deltamusic {
           voice.vibratoCtr--;
         }
 
-        if (sample.pitchBend < 0) voice.pitchBend += sample.pitchBend;
-          else voice.pitchBend -= sample.pitchBend;
+        if (sample.pitchBend < 0) {
+		voice.pitchBend += sample.pitchBend;
+		}
+          else {
+			  voice.pitchBend -= sample.pitchBend;
+		  }
 
         if (voice.row) {
           row = voice.row;
@@ -162,6 +166,7 @@ package neoart.flod.deltamusic {
               break;
             case 6:
               sample.vibratoStep = row.param;
+			  break;
             case 7:
               sample.vibratoLen = row.param;
               break;
@@ -246,7 +251,9 @@ package neoart.flod.deltamusic {
         }
 
         if (sample.portamento)
-          value = voice.period;
+		{
+			 value = voice.period;
+		}
         else {
           value = PERIODS[int(voice.note + sample.arpeggio[voice.arpeggioPos])];
           voice.arpeggioPos = ++voice.arpeggioPos & 7;
@@ -343,7 +350,17 @@ package neoart.flod.deltamusic {
     }
 
     override protected function loader(stream:ByteArray):void {
-      var data:Vector.<int>, i:int, id:String, index:int, j:int, len:int, position:int, row:AmigaRow, sample:D1Sample, step:AmigaStep, value:int;
+      var data:Vector.<int>;
+	  var i:int;
+	  var id:String;
+	  var index:int; 
+	  var j:int; 
+	  var len:int; 
+	  var position:int;
+	  var row:AmigaRow; 
+	  var sample:D1Sample;
+	  var step:AmigaStep;
+	  var value:int;
       id = stream.readMultiByte(4, ENCODING);
       if (id != "ALL ") return;
 
@@ -421,8 +438,10 @@ package neoart.flod.deltamusic {
           sample.synth  = sample.synth ? 0 : 1;
 
           if (sample.synth) {
-            for (j = 0; j < 48; ++j)
-              sample.table[j] = stream.readByte();
+            for (j = 0; j < 48; ++j) {
+				 sample.table[j] = stream.readByte();
+			}
+             
 
             len = data[index] - 78;
           } else {
@@ -443,14 +462,13 @@ package neoart.flod.deltamusic {
       version = 1;
     }
 
-    private const
-      PERIODS:Vector.<int> = Vector.<int>([
-        0000,6848,6464,6096,5760,5424,5120,4832,4560,4304,4064,3840,
+    private var PERIODS:Vector.<int> = Vector.<int>([0,
+	    6848,6464,6096,5760,5424,5120,4832,4560,4304,4064,3840,
         3616,3424,3232,3048,2880,2712,2560,2416,2280,2152,2032,1920,
-        1808,1712,1616,1524,1440,1356,1280,1208,1140,1076,0960,0904,
-        0856,0808,0762,0720,0678,0640,0604,0570,0538,0508,0480,0452,
-        0428,0404,0381,0360,0339,0320,0302,0285,0269,0254,0240,0226,
-        0214,0202,0190,0180,0170,0160,0151,0143,0135,0127,0120,0113,
-        0113,0113,0113,0113,0113,0113,0113,0113,0113,0113,0113,0113]);
+        1808,1712,1616,1524,1440,1356,1280,1208,1140,1076,960,904,
+        856,808,762,720,678,640,604,570,538,508,480,452,
+        428,404,381,360,339,320,302,285,269,254,240,226,
+        214,202,190,180,170,160,151,143,135,127,120,113,
+        113,113,113,113,113,113,113,113,113,113,113,113]);
   }
 }

--- a/Flod Flash/src/neoart/flod/deltamusic/D1Sample.as
+++ b/Flod Flash/src/neoart/flod/deltamusic/D1Sample.as
@@ -19,23 +19,23 @@ package neoart.flod.deltamusic {
   import neoart.flod.core.*;
 
   public final class D1Sample extends AmigaSample {
-    internal var
-      synth        : int,
-      attackStep   : int,
-      attackDelay  : int,
-      decayStep    : int,
-      decayDelay   : int,
-      releaseStep  : int,
-      releaseDelay : int,
-      sustain      : int,
-      arpeggio     : Vector.<int>,
-      pitchBend    : int,
-      portamento   : int,
-      table        : Vector.<int>,
-      tableDelay   : int,
-      vibratoWait  : int,
-      vibratoStep  : int,
-      vibratoLen   : int;
+    
+    internal var synth        : int;
+    internal var attackStep   : int;
+    internal var attackDelay  : int;
+    internal var decayStep    : int;
+    internal var decayDelay   : int;
+    internal var releaseStep  : int;
+    internal var releaseDelay : int;
+    internal var sustain      : int;
+    internal var arpeggio     : Vector.<int>;
+    internal var pitchBend    : int;
+    internal var portamento   : int;
+    internal var table        : Vector.<int>;
+    internal var tableDelay   : int;
+    internal var vibratoWait  : int;
+    internal var vibratoStep  : int;
+    internal var vibratoLen   : int;
 
     public function D1Sample() {
       arpeggio = new Vector.<int>( 8, true);

--- a/Flod Flash/src/neoart/flod/deltamusic/D1Voice.as
+++ b/Flod Flash/src/neoart/flod/deltamusic/D1Voice.as
@@ -19,32 +19,32 @@ package neoart.flod.deltamusic {
   import neoart.flod.core.*;
 
   public final class D1Voice {
-    internal var
-      index         : int,
-      next          : D1Voice,
-      channel       : AmigaChannel,
-      sample        : D1Sample,
-      trackPos      : int,
-      patternPos    : int,
-      status        : int,
-      speed         : int,
-      step          : AmigaStep,
-      row           : AmigaRow,
-      note          : int,
-      period        : int,
-      arpeggioPos   : int,
-      pitchBend     : int,
-      tableCtr      : int,
-      tablePos      : int,
-      vibratoCtr    : int,
-      vibratoDir    : int,
-      vibratoPos    : int,
-      vibratoPeriod : int,
-      volume        : int,
-      attackCtr     : int,
-      decayCtr      : int,
-      releaseCtr    : int,
-      sustain       : int;
+    
+    internal var index         : int;
+    internal var next          : D1Voice;
+    internal var channel       : AmigaChannel;
+    internal var sample        : D1Sample;
+    internal var trackPos      : int;
+    internal var patternPos    : int;
+    internal var status        : int;
+    internal var speed         : int;
+    internal var step          : AmigaStep;
+    internal var row           : AmigaRow;
+    internal var note          : int;
+    internal var period        : int;
+    internal var arpeggioPos   : int;
+    internal var pitchBend     : int;
+    internal var tableCtr      : int;
+    internal var tablePos      : int;
+    internal var vibratoCtr    : int;
+    internal var vibratoDir    : int;
+    internal var vibratoPos    : int;
+    internal var vibratoPeriod : int;
+    internal var volume        : int;
+    internal var attackCtr     : int;
+    internal var decayCtr      : int;
+    internal var releaseCtr    : int;
+    internal var sustain       : int;
 
     public function D1Voice(index:int) {
       this.index = index;

--- a/Flod Flash/src/neoart/flod/deltamusic/D2Player.as
+++ b/Flod Flash/src/neoart/flod/deltamusic/D2Player.as
@@ -20,14 +20,14 @@ package neoart.flod.deltamusic {
   import neoart.flod.core.*;
 
   public final class D2Player extends AmigaPlayer {
-    private var
-      tracks    : Vector.<AmigaStep>,
-      patterns  : Vector.<AmigaRow>,
-      samples   : Vector.<D2Sample>,
-      data      : Vector.<int>,
-      arpeggios : Vector.<int>,
-      voices    : Vector.<D2Voice>,
-      noise     : uint;
+    
+    private var tracks    : Vector.<AmigaStep>;
+    private var patterns  : Vector.<AmigaRow>;
+    private var samples   : Vector.<D2Sample>;
+    private var data      : Vector.<int>;
+    private var arpeggios : Vector.<int>;
+    private var voices    : Vector.<D2Voice>;
+    private var noise     : uint;
 
     public function D2Player(amiga:Amiga = null) {
       super(amiga);
@@ -173,8 +173,12 @@ package neoart.flod.deltamusic {
         }
         value = sample.vibratos[voice.vibratoPos];
 
-        if (voice.vibratoDir) voice.vibratoPeriod -= value;
-          else voice.vibratoPeriod += value;
+        if (voice.vibratoDir) {
+			voice.vibratoPeriod -= value;
+		}
+          else {
+			  voice.vibratoPeriod += value;
+		  }
 
         if (--voice.vibratoCtr == 0) {
           voice.vibratoCtr = sample.vibratos[int(voice.vibratoPos + 1)];

--- a/Flod Flash/src/neoart/flod/deltamusic/D2Sample.as
+++ b/Flod Flash/src/neoart/flod/deltamusic/D2Sample.as
@@ -19,13 +19,13 @@ package neoart.flod.deltamusic {
   import neoart.flod.core.*;
 
   public final class D2Sample extends AmigaSample {
-    internal var
-      index     : int,
-      pitchBend : int,
-      synth     : int,
-      table     : Vector.<int>,
-      vibratos  : Vector.<int>,
-      volumes   : Vector.<int>;
+    
+    internal var index     : int;
+    internal var pitchBend : int;
+    internal var synth     : int;
+    internal var table     : Vector.<int>;
+    internal var vibratos  : Vector.<int>;
+    internal var volumes   : Vector.<int>;
 
     public function D2Sample() {
       table    = new Vector.<int>(48, true);

--- a/Flod Flash/src/neoart/flod/deltamusic/D2Voice.as
+++ b/Flod Flash/src/neoart/flod/deltamusic/D2Voice.as
@@ -19,36 +19,36 @@ package neoart.flod.deltamusic {
   import neoart.flod.core.*;
 
   public final class D2Voice {
-    internal var
-      index          : int,
-      next           : D2Voice,
-      channel        : AmigaChannel,
-      sample         : D2Sample,
-      trackPtr       : int,
-      trackPos       : int,
-      trackLen       : int,
-      patternPos     : int,
-      restart        : int,
-      step           : AmigaStep,
-      row            : AmigaRow,
-      note           : int,
-      period         : int,
-      finalPeriod    : int,
-      arpeggioPtr    : int,
-      arpeggioPos    : int,
-      pitchBend      : int,
-      portamento     : int,
-      tableCtr       : int,
-      tablePos       : int,
-      vibratoCtr     : int,
-      vibratoDir     : int,
-      vibratoPos     : int,
-      vibratoPeriod  : int,
-      vibratoSustain : int,
-      volume         : int,
-      volumeMax      : int,
-      volumePos      : int,
-      volumeSustain  : int;
+    
+    internal var index          : int;
+    internal var next           : D2Voice;
+    internal var channel        : AmigaChannel;
+    internal var sample         : D2Sample;
+    internal var trackPtr       : int;
+    internal var trackPos       : int;
+    internal var trackLen       : int;
+    internal var patternPos     : int;
+    internal var restart        : int;
+    internal var step           : AmigaStep;
+    internal var row            : AmigaRow;
+    internal var note           : int;
+    internal var period         : int;
+    internal var finalPeriod    : int;
+    internal var arpeggioPtr    : int;
+    internal var arpeggioPos    : int;
+    internal var pitchBend      : int;
+    internal var portamento     : int;
+    internal var tableCtr       : int;
+    internal var tablePos       : int;
+    internal var vibratoCtr     : int;
+    internal var vibratoDir     : int;
+    internal var vibratoPos     : int;
+    internal var vibratoPeriod  : int;
+    internal var vibratoSustain : int;
+    internal var volume         : int;
+    internal var volumeMax      : int;
+    internal var volumePos      : int;
+    internal var volumeSustain  : int;
 
     public function D2Voice(index:int) {
       this.index = index;

--- a/Flod Flash/src/neoart/flod/digitalmugician/DMPlayer.as
+++ b/Flod Flash/src/neoart/flod/digitalmugician/DMPlayer.as
@@ -20,26 +20,26 @@ package neoart.flod.digitalmugician {
   import neoart.flod.core.*;
 
   public final class DMPlayer extends AmigaPlayer {
-    private var
-      songs       : Vector.<DMSong>,
-      patterns    : Vector.<AmigaRow>,
-      samples     : Vector.<DMSample>,
-      voices      : Vector.<DMVoice>,
-      buffer1     : int,
-      buffer2     : int,
-      song1       : DMSong,
-      song2       : DMSong,
-      trackPos    : int,
-      patternPos  : int,
-      patternLen  : int,
-      patternEnd  : int,
-      stepEnd     : int,
-      numChannels : int,
-      arpeggios   : Vector.<int>,
-      averages    : Vector.<int>,
-      volumes     : Vector.<int>,
-      mixChannel  : AmigaChannel,
-      mixPeriod   : int;
+    
+    private var songs       : Vector.<DMSong>;
+    private var patterns    : Vector.<AmigaRow>;
+    private var samples     : Vector.<DMSample>;
+    private var voices      : Vector.<DMVoice>;
+    private var buffer1     : int;
+    private var buffer2     : int;
+    private var song1       : DMSong;
+    private var song2       : DMSong;
+    private var trackPos    : int;
+    private var patternPos  : int;
+    private var patternLen  : int;
+    private var patternEnd  : int;
+    private var stepEnd     : int;
+    private var numChannels : int;
+    private var arpeggios   : Vector.<int>;
+    private var averages    : Vector.<int>;
+    private var volumes     : Vector.<int>;
+    private var mixChannel  : AmigaChannel;
+    private var mixPeriod   : int;
 
     public function DMPlayer(amiga:Amiga = null) {
       super(amiga);
@@ -96,15 +96,24 @@ package neoart.flod.digitalmugician {
 
               if (voice.val1 == 1) {
                 idx += voice.pitch;
-                if (idx < 0) voice.period = 0;
-                  else voice.period = PERIODS[idx];
+                if (idx < 0) {
+					voice.period = 0;
+				}
+                  else {
+					  voice.period = PERIODS[idx];
+				  }
               }
             } else {
               voice.pitch = row.note;
               idx += voice.pitch;
 
-              if (idx < 0) voice.period = 0;
-                else voice.period = PERIODS[idx];
+              if (idx < 0) {
+			  voice.period = 0;
+			  
+			  }
+                else {
+					voice.period = PERIODS[idx];
+				}
             }
 
             if (voice.val1 == 11) sample.arpeggio = voice.val2 & 7;
@@ -259,14 +268,21 @@ package neoart.flod.digitalmugician {
 
                   for (j = 0; j < len; ++j) {
                     src1 = memory[dst] + value;
-                    if (src1 < -128) src1 += 256;
-                      else if (src1 > 127) src1 -= 256;
+                    if (src1 < -128) {
+						src1 += 256;
+					}
+                      else if (src1 > 127) {
+						  src1 -= 256;
+					  }
 
                     memory[dst++] = src1;
                     value += idx;
 
-                    if (value < -128) value += 256;
-                      else if (value > 127) value -= 256;
+                    if (value < -128) {
+					value += 256;}
+                      else if (value > 127) {
+						  value -= 256;
+					  }
                   }
                   break;
                 case 9:   //addition
@@ -445,8 +461,13 @@ package neoart.flod.digitalmugician {
             voice.mixSpeed = (src2 | ((dst / j) & 255)) << 8;
           }
 
-          if (voice.mixMute) voice.mixVolume = 0;
-            else voice.mixVolume = voice.volume << 8;
+          if (voice.mixMute) {
+		  voice.mixVolume = 0;
+		  
+		  }
+            else {
+				voice.mixVolume = voice.volume << 8;
+			}
         }
 
         for (i = 0; i < 350; ++i) {
@@ -569,13 +590,22 @@ package neoart.flod.digitalmugician {
       var data:int, i:int, id:String, index:Vector.<int>, instr:int, j:int, len:int, position:int, row:AmigaRow, sample:DMSample, song:DMSong, step:AmigaStep;
       id = stream.readMultiByte(24, ENCODING);
 
-      if (id == " MUGICIAN/SOFTEYES 1990 ") version = DIGITALMUG_V1;
-        else if (id == " MUGICIAN2/SOFTEYES 1990") version = DIGITALMUG_V2;
-          else return;
+      if (id == " MUGICIAN/SOFTEYES 1990 ") {
+			version = DIGITALMUG_V1;
+		}
+        else if (id == " MUGICIAN2/SOFTEYES 1990") {
+			version = DIGITALMUG_V2;
+		}
+		  else {
+			  return;
+		  }
 
       stream.position = 28;
       index = new Vector.<int>(8, true);
-      for (; i < 8; ++i) index[i] = stream.readUnsignedInt();
+      for (; i < 8; ++i) {
+		index[i] = stream.readUnsignedInt();
+	  
+	  }
 
       stream.position = 76;
 
@@ -746,9 +776,9 @@ package neoart.flod.digitalmugician {
       }
     }
 
-    public static const
-      DIGITALMUG_V1 = 1,
-      DIGITALMUG_V2 = 2;
+    
+    public static const DIGITALMUG_V1 :int = 1;
+    public static const DIGITALMUG_V2 :int = 2;
 
     private const
       PERIODS: Vector.<int> = Vector.<int>([

--- a/Flod Flash/src/neoart/flod/digitalmugician/DMSample.as
+++ b/Flod Flash/src/neoart/flod/digitalmugician/DMSample.as
@@ -19,22 +19,22 @@ package neoart.flod.digitalmugician {
   import neoart.flod.core.*;
 
   public final class DMSample extends AmigaSample {
-    internal var
-      wave        : int,
-      waveLen     : int,
-      finetune    : int,
-      arpeggio    : int,
-      pitch       : int,
-      pitchDelay  : int,
-      pitchLoop   : int,
-      pitchSpeed  : int,
-      effect      : int,
-      effectDone  : int,
-      effectStep  : int,
-      effectSpeed : int,
-      source1     : int,
-      source2     : int,
-      volumeLoop  : int,
-      volumeSpeed : int;
+    
+    internal var wave        : int;
+    internal var waveLen     : int;
+    internal var finetune    : int;
+    internal var arpeggio    : int;
+    internal var pitch       : int;
+    internal var pitchDelay  : int;
+    internal var pitchLoop   : int;
+    internal var pitchSpeed  : int;
+    internal var effect      : int;
+    internal var effectDone  : int;
+    internal var effectStep  : int;
+    internal var effectSpeed : int;
+    internal var source1     : int;
+    internal var source2     : int;
+    internal var volumeLoop  : int;
+    internal var volumeSpeed : int;
   }
 }

--- a/Flod Flash/src/neoart/flod/digitalmugician/DMSong.as
+++ b/Flod Flash/src/neoart/flod/digitalmugician/DMSong.as
@@ -19,13 +19,13 @@ package neoart.flod.digitalmugician {
   import neoart.flod.core.*;
 
   public final class DMSong {
-    internal var
-      title    : String,
-      speed    : int,
-      length   : int,
-      loop     : int,
-      loopStep : int,
-      tracks   : Vector.<AmigaStep>;
+    
+    internal var title    : String;
+    internal var speed    : int;
+    internal var length   : int;
+    internal var loop     : int;
+    internal var loopStep : int;
+    internal var tracks   : Vector.<AmigaStep>;
 
     public function DMSong() {
       tracks = new Vector.<AmigaStep>();

--- a/Flod Flash/src/neoart/flod/digitalmugician/DMVoice.as
+++ b/Flod Flash/src/neoart/flod/digitalmugician/DMVoice.as
@@ -19,30 +19,30 @@ package neoart.flod.digitalmugician {
   import neoart.flod.core.*;
 
   public final class DMVoice {
-    internal var
-      channel      : AmigaChannel,
-      sample       : DMSample,
-      step         : AmigaStep,
-      note         : int,
-      period       : int,
-      val1         : int,
-      val2         : int,
-      finalPeriod  : int,
-      arpeggioStep : int,
-      effectCtr    : int,
-      pitch        : int,
-      pitchCtr     : int,
-      pitchStep    : int,
-      portamento   : int,
-      volume       : int,
-      volumeCtr    : int,
-      volumeStep   : int,
-      mixMute      : int,
-      mixPtr       : int,
-      mixEnd       : int,
-      mixSpeed     : int,
-      mixStep      : int,
-      mixVolume    : int;
+    
+    internal var channel      : AmigaChannel;
+    internal var sample       : DMSample;
+    internal var step         : AmigaStep;
+    internal var note         : int;
+    internal var period       : int;
+    internal var val1         : int;
+    internal var val2         : int;
+    internal var finalPeriod  : int;
+    internal var arpeggioStep : int;
+    internal var effectCtr    : int;
+    internal var pitch        : int;
+    internal var pitchCtr     : int;
+    internal var pitchStep    : int;
+    internal var portamento   : int;
+    internal var volume       : int;
+    internal var volumeCtr    : int;
+    internal var volumeStep   : int;
+    internal var mixMute      : int;
+    internal var mixPtr       : int;
+    internal var mixEnd       : int;
+    internal var mixSpeed     : int;
+    internal var mixStep      : int;
+    internal var mixVolume    : int;
 
     internal function initialize():void {
       sample       = null;

--- a/Flod Flash/src/neoart/flod/fasttracker/F2Data.as
+++ b/Flod Flash/src/neoart/flod/fasttracker/F2Data.as
@@ -18,13 +18,13 @@
 package neoart.flod.fasttracker {
 
   public final class F2Data {
-    internal var
-      points    : Vector.<F2Point>,
-      total     : int,
-      sustain   : int,
-      loopStart : int,
-      loopEnd   : int,
-      flags     : int;
+    
+    internal var points    : Vector.<F2Point>;
+    internal var total     : int;
+    internal var sustain   : int;
+    internal var loopStart : int;
+    internal var loopEnd   : int;
+    internal var flags     : int;
 
     public function F2Data() {
       points = new Vector.<F2Point>(12, true);

--- a/Flod Flash/src/neoart/flod/fasttracker/F2Envelope.as
+++ b/Flod Flash/src/neoart/flod/fasttracker/F2Envelope.as
@@ -18,13 +18,13 @@
 package neoart.flod.fasttracker {
 
   public final class F2Envelope {
-    internal var
-      value    : int,
-      position : int,
-      frame    : int,
-      delta    : int,
-      fraction : int,
-      stopped  : int;
+    
+    internal var  value    : int;
+    internal var  position : int;
+    internal var  frame    : int;
+    internal var  delta    : int;
+    internal var  fraction : int;
+    internal var  stopped  : int;
 
     internal function reset():void {
       value    = 0;

--- a/Flod Flash/src/neoart/flod/fasttracker/F2Instrument.as
+++ b/Flod Flash/src/neoart/flod/fasttracker/F2Instrument.as
@@ -18,19 +18,19 @@
 package neoart.flod.fasttracker {
 
   public final class F2Instrument {
-    internal var
-      name         : String = "",
-      samples      : Vector.<F2Sample>,
-      noteSamples  : Vector.<int>,
-      fadeout      : int,
-      volData      : F2Data,
-      volEnabled   : int,
-      panData      : F2Data,
-      panEnabled   : int,
-      vibratoType  : int,
-      vibratoSweep : int,
-      vibratoSpeed : int,
-      vibratoDepth : int;
+    
+    internal var name         : String = "";
+    internal var samples      : Vector.<F2Sample>;
+    internal var noteSamples  : Vector.<int>;
+    internal var fadeout      : int;
+    internal var volData      : F2Data;
+    internal var volEnabled   : int;
+    internal var panData      : F2Data;
+    internal var panEnabled   : int;
+    internal var vibratoType  : int;
+    internal var vibratoSweep : int;
+    internal var vibratoSpeed : int;
+    internal var vibratoDepth : int;
 
     public function F2Instrument() {
       noteSamples = new Vector.<int>(96, true);

--- a/Flod Flash/src/neoart/flod/fasttracker/F2Pattern.as
+++ b/Flod Flash/src/neoart/flod/fasttracker/F2Pattern.as
@@ -18,12 +18,12 @@
 package neoart.flod.fasttracker {
 
   public final class F2Pattern {
-    internal var
-      rows   : Vector.<F2Row>,
-      length : int,
-      size   : int;
+    
+    internal var rows   : Vector.<F2Row>;
+    internal var length : int;
+    internal var size   : int;
 
-    public function F2Pattern(length, channels) {
+    public function F2Pattern(length :int, channels:int) {
       size = length * channels;
       rows = new Vector.<F2Row>(size, true);
       this.length = length;

--- a/Flod Flash/src/neoart/flod/fasttracker/F2Player.as
+++ b/Flod Flash/src/neoart/flod/fasttracker/F2Player.as
@@ -20,20 +20,20 @@ package neoart.flod.fasttracker {
   import neoart.flod.core.*;
 
   public final class F2Player extends SBPlayer {
-    internal var
-      patterns      : Vector.<F2Pattern>,
-      instruments   : Vector.<F2Instrument>,
-      linear        : int;
-    private var
-      voices        : Vector.<F2Voice>,
-      order         : int,
-      position      : int,
-      nextOrder     : int,
-      nextPosition  : int,
-      pattern       : F2Pattern,
-      patternDelay  : int,
-      patternOffset : int,
-      complete      : int;
+    
+    internal var patterns      : Vector.<F2Pattern>;
+    internal var instruments   : Vector.<F2Instrument>;
+    internal var linear        : int;
+    
+    private var voices        : Vector.<F2Voice>;
+    private var order         : int;
+    private var position      : int;
+    private var nextOrder     : int;
+    private var nextPosition  : int;
+    private var pattern       : F2Pattern;
+    private var patternDelay  : int;
+    private var patternOffset : int;
+    private var complete      : int;
 
     public function F2Player(mixer:Soundblaster = null) {
       super(mixer);
@@ -209,8 +209,12 @@ package neoart.flod.fasttracker {
               case FX_POSITION_JUMP:
                 nextOrder = row.param;
 
-                if (nextOrder >= length) complete = 1;
-                  else nextPosition = 0;
+                if (nextOrder >= length) {
+					complete = 1;
+				}
+                 else {
+					  nextPosition = 0;
+				}
 
                 jumpFlag      = 1;
                 patternOffset = 0;
@@ -290,8 +294,12 @@ package neoart.flod.fasttracker {
                 break;
               case FX_SET_SPEED:
                 if (!row.param) break;
-                if (row.param < 32) timer = row.param;
-                  else mixer.samplesTick = 110250 / row.param;
+                if (row.param < 32) {
+					timer = row.param;
+				}
+                  else {
+					  mixer.samplesTick = 110250 / row.param;
+				}
                 break;
               case FX_SET_GLOBAL_VOLUME:
                 master = row.param;
@@ -644,13 +652,13 @@ package neoart.flod.fasttracker {
           panning = (voice.panEnvelope.value << 2);
           flags |= UPDATE_PANNING;
 
-          if (panning < 0) panning = 0;
-            else if (panning > 255) panning = 255;
+          if (panning < 0) {panning = 0;}
+            else if (panning > 255) {panning = 255;}
         }
 
         if (flags & UPDATE_VOLUME) {
-          if (volume < 0) volume = 0;
-            else if (volume > 64) volume = 64;
+          if (volume < 0) {volume = 0;}
+            else if (volume > 64) {volume = 64;}
 
           chan.volume = VOLUMES[int((volume * master) >> 6)];
           chan.lvol = chan.volume * chan.lpan;
@@ -765,8 +773,11 @@ package neoart.flod.fasttracker {
           panning = (voice.panEnvelope.value << 2);
           flags |= UPDATE_PANNING;
 
-          if (panning < 0) panning = 0;
-            else if (panning > 255) panning = 255;
+          if (panning < 0) {
+		  panning = 0;
+		  
+		  }
+            else if (panning > 255) {panning = 255;}
         }
 
         if (!chan.enabled) {
@@ -777,8 +788,8 @@ package neoart.flod.fasttracker {
         }
 
         if (flags & UPDATE_VOLUME) {
-          if (volume < 0) volume = 0;
-            else if (volume > 64) volume = 64;
+          if (volume < 0) {volume = 0;}
+            else if (volume > 64) {volume = 64;}
 
           volume = VOLUMES[int((volume * master) >> 6)];
           lvol = volume * PANNING[int(256 - panning)];
@@ -1068,7 +1079,7 @@ package neoart.flod.fasttracker {
       sample.length = 220;
       sample.data = new Vector.<Number>(220, true);
 
-      for (i = 0; i < 220; ++i) sample.data[i] = 0.0;
+      for (i = 0; i < 220; ++i) {sample.data[i] = 0.0;}
 
       instr.samples[0] = sample;
       instruments[0] = instr;
@@ -1169,79 +1180,79 @@ package neoart.flod.fasttracker {
           break;
       }
 
-      if (voice.volume < 0) voice.volume = 0;
-        else if (voice.volume > 64) voice.volume = 64;
+      if (voice.volume < 0) {voice.volume = 0;}
+        else if (voice.volume > 64) {voice.volume = 64;}
 
       voice.flags |= UPDATE_VOLUME;
     }
 
-    internal static const
-      UPDATE_PERIOD    : int = 1,
-      UPDATE_VOLUME    : int = 2,
-      UPDATE_PANNING   : int = 4,
-      UPDATE_TRIGGER   : int = 8,
-      UPDATE_ALL       : int = 15,
-      SHORT_RAMP       : int = 32,
+    
+    internal static const UPDATE_PERIOD    : int = 1;
+    internal static const UPDATE_VOLUME    : int = 2;
+    internal static const UPDATE_PANNING   : int = 4;
+    internal static const UPDATE_TRIGGER   : int = 8;
+    internal static const UPDATE_ALL       : int = 15;
+    internal static const SHORT_RAMP       : int = 32;
 
-      ENVELOPE_ON      : int = 1,
-      ENVELOPE_SUSTAIN : int = 2,
-      ENVELOPE_LOOP    : int = 4,
+    internal static const ENVELOPE_ON      : int = 1;
+    internal static const ENVELOPE_SUSTAIN : int = 2;
+    internal static const ENVELOPE_LOOP    : int = 4;
 
-      LOWER_NOTE       : int = 0,
-      HIGHER_NOTE      : int = 118,
-      KEYOFF_NOTE      : int = 97,
+    internal static const LOWER_NOTE       : int = 0;
+    internal static const HIGHER_NOTE      : int = 118;
+    internal static const KEYOFF_NOTE      : int = 97;
 
-      FX_ARPEGGIO                : int = 0,
-      FX_PORTAMENTO_UP           : int = 1,
-      FX_PORTAMENTO_DOWN         : int = 2,
-      FX_TONE_PORTAMENTO         : int = 3,
-      FX_VIBRATO                 : int = 4,
-      FX_TONE_PORTA_VOLUME_SLIDE : int = 5,
-      FX_VIBRATO_VOLUME_SLIDE    : int = 6,
-      FX_TREMOLO                 : int = 7,
-      FX_SET_PANNING             : int = 8,
-      FX_SAMPLE_OFFSET           : int = 9,
-      FX_VOLUME_SLIDE            : int = 10,
-      FX_POSITION_JUMP           : int = 11,
-      FX_SET_VOLUME              : int = 12,
-      FX_PATTERN_BREAK           : int = 13,
-      FX_EXTENDED_EFFECTS        : int = 14,
-      FX_SET_SPEED               : int = 15,
-      FX_SET_GLOBAL_VOLUME       : int = 16,
-      FX_GLOBAL_VOLUME_SLIDE     : int = 17,
-      FX_KEYOFF                  : int = 20,
-      FX_SET_ENVELOPE_POSITION   : int = 21,
-      FX_PANNING_SLIDE           : int = 24,
-      FX_MULTI_RETRIG_NOTE       : int = 27,
-      FX_TREMOR                  : int = 29,
-      FX_EXTRA_FINE_PORTAMENTO   : int = 33,
+    internal static const FX_ARPEGGIO                : int = 0;
+    internal static const FX_PORTAMENTO_UP           : int = 1;
+    internal static const FX_PORTAMENTO_DOWN         : int = 2;
+    internal static const FX_TONE_PORTAMENTO         : int = 3;
+    internal static const FX_VIBRATO                 : int = 4;
+    internal static const FX_TONE_PORTA_VOLUME_SLIDE : int = 5;
+    internal static const FX_VIBRATO_VOLUME_SLIDE    : int = 6;
+    internal static const FX_TREMOLO                 : int = 7;
+    internal static const FX_SET_PANNING             : int = 8;
+    internal static const FX_SAMPLE_OFFSET           : int = 9;
+    internal static const FX_VOLUME_SLIDE            : int = 10;
+    internal static const FX_POSITION_JUMP           : int = 11;
+    internal static const FX_SET_VOLUME              : int = 12;
+    internal static const FX_PATTERN_BREAK           : int = 13;
+    internal static const FX_EXTENDED_EFFECTS        : int = 14;
+    internal static const FX_SET_SPEED               : int = 15;
+    internal static const FX_SET_GLOBAL_VOLUME       : int = 16;
+    internal static const FX_GLOBAL_VOLUME_SLIDE     : int = 17;
+    internal static const FX_KEYOFF                  : int = 20;
+    internal static const FX_SET_ENVELOPE_POSITION   : int = 21;
+    internal static const FX_PANNING_SLIDE           : int = 24;
+    internal static const FX_MULTI_RETRIG_NOTE       : int = 27;
+    internal static const FX_TREMOR                  : int = 29;
+    internal static const FX_EXTRA_FINE_PORTAMENTO   : int = 33;
 
-      EX_FINE_PORTAMENTO_UP      : int = 1,
-      EX_FINE_PORTAMENTO_DOWN    : int = 2,
-      EX_GLISSANDO_CONTROL       : int = 3,
-      EX_VIBRATO_CONTROL         : int = 4,
-      EX_SET_FINETUNE            : int = 5,
-      EX_PATTERN_LOOP            : int = 6,
-      EX_TREMOLO_CONTROL         : int = 7,
-      EX_RETRIG_NOTE             : int = 9,
-      EX_FINE_VOLUME_SLIDE_UP    : int = 10,
-      EX_FINE_VOLUME_SLIDE_DOWN  : int = 11,
-      EX_NOTE_CUT                : int = 12,
-      EX_NOTE_DELAY              : int = 13,
-      EX_PATTERN_DELAY           : int = 14,
+    internal static const EX_FINE_PORTAMENTO_UP      : int = 1;
+    internal static const EX_FINE_PORTAMENTO_DOWN    : int = 2;
+    internal static const EX_GLISSANDO_CONTROL       : int = 3;
+    internal static const EX_VIBRATO_CONTROL         : int = 4;
+    internal static const EX_SET_FINETUNE            : int = 5;
+    internal static const EX_PATTERN_LOOP            : int = 6;
+    internal static const EX_TREMOLO_CONTROL         : int = 7;
+    internal static const EX_RETRIG_NOTE             : int = 9;
+    internal static const EX_FINE_VOLUME_SLIDE_UP    : int = 10;
+    internal static const EX_FINE_VOLUME_SLIDE_DOWN  : int = 11;
+    internal static const EX_NOTE_CUT                : int = 12;
+    internal static const EX_NOTE_DELAY              : int = 13;
+    internal static const EX_PATTERN_DELAY           : int = 14;
 
-      VX_VOLUME_SLIDE_DOWN       : int = 6,
-      VX_VOLUME_SLIDE_UP         : int = 7,
-      VX_FINE_VOLUME_SLIDE_DOWN  : int = 8,
-      VX_FINE_VOLUME_SLIDE_UP    : int = 9,
-      VX_SET_VIBRATO_SPEED       : int = 10,
-      VX_VIBRATO                 : int = 11,
-      VX_SET_PANNING             : int = 12,
-      VX_PANNING_SLIDE_LEFT      : int = 13,
-      VX_PANNING_SLIDE_RIGHT     : int = 14,
-      VX_TONE_PORTAMENTO         : int = 15,
+    internal static const VX_VOLUME_SLIDE_DOWN       : int = 6;
+    internal static const VX_VOLUME_SLIDE_UP         : int = 7;
+    internal static const VX_FINE_VOLUME_SLIDE_DOWN  : int = 8;
+    internal static const VX_FINE_VOLUME_SLIDE_UP    : int = 9;
+    internal static const VX_SET_VIBRATO_SPEED       : int = 10;
+    internal static const VX_VIBRATO                 : int = 11;
+    internal static const VX_SET_PANNING             : int = 12;
+    internal static const VX_PANNING_SLIDE_LEFT      : int = 13;
+    internal static const VX_PANNING_SLIDE_RIGHT     : int = 14;
+    internal static const VX_TONE_PORTAMENTO         : int = 15;
 
-      PANNING : Vector.<Number> = Vector.<Number>([
+    internal static const PANNING : Vector.<Number> = Vector.<Number>([
         0.000000,0.044170,0.062489,0.076523,0.088371,0.098821,0.108239,0.116927,0.124977,
         0.132572,0.139741,0.146576,0.153077,0.159335,0.165350,0.171152,0.176772,0.182210,
         0.187496,0.192630,0.197643,0.202503,0.207273,0.211951,0.216477,0.220943,0.225348,
@@ -1270,9 +1281,9 @@ package neoart.flod.fasttracker {
         0.662890,0.664378,0.665836,0.667294,0.668783,0.670241,0.671699,0.673127,0.674585,
         0.676043,0.677471,0.678929,0.680357,0.681785,0.683213,0.684641,0.686068,0.687496,
         0.688894,0.690321,0.691749,0.693147,0.694574,0.695972,0.697369,0.698767,0.700164,
-        0.701561,0.702928,0.704326,0.705723,0.707110]),
+        0.701561, 0.702928, 0.704326, 0.705723, 0.707110]);
 
-      VOLUMES : Vector.<Number> = Vector.<Number>([
+    internal static const VOLUMES : Vector.<Number> = Vector.<Number>([
         0.000000,0.005863,0.013701,0.021569,0.029406,0.037244,0.045082,0.052919,0.060757,
         0.068625,0.076463,0.084300,0.092138,0.099976,0.107844,0.115681,0.123519,0.131357,
         0.139194,0.147032,0.154900,0.162738,0.170575,0.178413,0.186251,0.194119,0.201956,
@@ -1280,9 +1291,9 @@ package neoart.flod.fasttracker {
         0.280394,0.288231,0.296069,0.303907,0.311744,0.319582,0.327450,0.335288,0.343125,
         0.350963,0.358800,0.366669,0.374506,0.382344,0.390182,0.398019,0.405857,0.413725,
         0.421563,0.429400,0.437238,0.445076,0.452944,0.460781,0.468619,0.476457,0.484294,
-        0.492132,0.500000]),
+        0.492132, 0.500000]);
 
-      PERIODS : Vector.<int> = Vector.<int>([
+    internal static const PERIODS : Vector.<int> = Vector.<int>([
         29024,27392,25856,24384,23040,21696,20480,19328,18240,17216,16256,15360,14512,
         13696,12928,12192,11520,10848,10240, 9664, 9120, 8608, 8128, 7680, 7256, 6848,
          6464, 6096, 5760, 5424, 5120, 4832, 4560, 4304, 4064, 3840, 3628, 3424, 3232,

--- a/Flod Flash/src/neoart/flod/fasttracker/F2Point.as
+++ b/Flod Flash/src/neoart/flod/fasttracker/F2Point.as
@@ -18,9 +18,9 @@
 package neoart.flod.fasttracker {
 
   public final class F2Point {
-    internal var
-      frame : int,
-      value : int;
+    
+    internal var  frame : int;
+     internal var value : int;
 
     public function F2Point(x:int = 0, y:int = 0) {
       frame = x;

--- a/Flod Flash/src/neoart/flod/fasttracker/F2Row.as
+++ b/Flod Flash/src/neoart/flod/fasttracker/F2Row.as
@@ -18,11 +18,11 @@
 package neoart.flod.fasttracker {
 
   public final class F2Row {
-    internal var
-      note       : int,
-      instrument : int,
-      volume     : int,
-      effect     : int,
-      param      : int;
+    
+    internal var note       : int;
+    internal var instrument : int;
+    internal var volume     : int;
+    internal var effect     : int;
+    internal var param      : int;
   }
 }

--- a/Flod Flash/src/neoart/flod/fasttracker/F2Sample.as
+++ b/Flod Flash/src/neoart/flod/fasttracker/F2Sample.as
@@ -19,9 +19,9 @@ package neoart.flod.fasttracker {
   import neoart.flod.core.*;
 
   public final class F2Sample extends SBSample {
-    public var
-      finetune : int,
-      panning  : int,
-      relative : int;
+    
+    public var finetune : int;
+    public var panning  : int;
+    public var relative : int;
   }
 }

--- a/Flod Flash/src/neoart/flod/fasttracker/F2Voice.as
+++ b/Flod Flash/src/neoart/flod/fasttracker/F2Voice.as
@@ -19,66 +19,66 @@ package neoart.flod.fasttracker {
   import neoart.flod.core.*;
 
   public final class F2Voice {
-    internal var
-      index          : int,
-      next           : F2Voice,
-      flags          : int,
-      delay          : int,
-      channel        : SBChannel,
-      patternLoop    : int,
-      patternLoopRow : int,
-      playing        : F2Instrument,
-      note           : int,
-      keyoff         : int,
-      period         : int,
-      finetune       : int,
-      arpDelta       : int,
-      vibDelta       : int,
-      instrument     : F2Instrument,
-      autoVibratoPos : int,
-      autoSweep      : int,
-      autoSweepPos   : int,
-      sample         : F2Sample,
-      sampleOffset   : int,
-      volume         : int,
-      volEnabled     : int,
-      volEnvelope    : F2Envelope,
-      volDelta       : int,
-      volSlide       : int,
-      volSlideMaster : int,
-      fineSlideU     : int,
-      fineSlideD     : int,
-      fadeEnabled    : int,
-      fadeDelta      : int,
-      fadeVolume     : int,
-      panning        : int,
-      panEnabled     : int,
-      panEnvelope    : F2Envelope,
-      panSlide       : int,
-      portaU         : int,
-      portaD         : int,
-      finePortaU     : int,
-      finePortaD     : int,
-      xtraPortaU     : int,
-      xtraPortaD     : int,
-      portaPeriod    : int,
-      portaSpeed     : int,
-      glissando      : int,
-      glissPeriod    : int,
-      vibratoPos     : int,
-      vibratoSpeed   : int,
-      vibratoDepth   : int,
-      vibratoReset   : int,
-      tremoloPos     : int,
-      tremoloSpeed   : int,
-      tremoloDepth   : int,
-      waveControl    : int,
-      tremorPos      : int,
-      tremorOn       : int,
-      tremorOff      : int,
-      tremorVolume   : int,
-      retrigx        : int,
-      retrigy        : int;
+    
+    internal var index          : int;
+    internal var next           : F2Voice;
+    internal var flags          : int;
+    internal var delay          : int;
+    internal var channel        : SBChannel;
+    internal var patternLoop    : int;
+    internal var patternLoopRow : int;
+    internal var playing        : F2Instrument;
+    internal var note           : int;
+    internal var keyoff         : int;
+    internal var period         : int;
+    internal var finetune       : int;
+    internal var arpDelta       : int;
+    internal var vibDelta       : int;
+    internal var instrument     : F2Instrument;
+    internal var autoVibratoPos : int;
+    internal var autoSweep      : int;
+    internal var autoSweepPos   : int;
+    internal var sample         : F2Sample;
+    internal var sampleOffset   : int;
+    internal var volume         : int;
+    internal var volEnabled     : int;
+    internal var volEnvelope    : F2Envelope;
+    internal var volDelta       : int;
+    internal var volSlide       : int;
+    internal var volSlideMaster : int;
+    internal var fineSlideU     : int;
+    internal var fineSlideD     : int;
+    internal var fadeEnabled    : int;
+    internal var fadeDelta      : int;
+    internal var fadeVolume     : int;
+    internal var panning        : int;
+    internal var panEnabled     : int;
+    internal var panEnvelope    : F2Envelope;
+    internal var panSlide       : int;
+    internal var portaU         : int;
+    internal var portaD         : int;
+    internal var finePortaU     : int;
+    internal var finePortaD     : int;
+    internal var xtraPortaU     : int;
+    internal var xtraPortaD     : int;
+    internal var portaPeriod    : int;
+    internal var portaSpeed     : int;
+    internal var glissando      : int;
+    internal var glissPeriod    : int;
+    internal var vibratoPos     : int;
+    internal var vibratoSpeed   : int;
+    internal var vibratoDepth   : int;
+    internal var vibratoReset   : int;
+    internal var tremoloPos     : int;
+    internal var tremoloSpeed   : int;
+    internal var tremoloDepth   : int;
+    internal var waveControl    : int;
+    internal var tremorPos      : int;
+    internal var tremorOn       : int;
+    internal var tremorOff      : int;
+    internal var tremorVolume   : int;
+    internal var retrigx        : int;
+    internal var retrigy        : int;
 
     public function F2Voice(index:int) {
       this.index = index;
@@ -118,8 +118,12 @@ package neoart.flod.fasttracker {
           delta = AUTOVIBRATO[autoVibratoPos];
           break;
         case 1:
-          if (autoVibratoPos < 128) delta = -64;
-            else delta = 64;
+          if (autoVibratoPos < 128) {
+			  delta = -64;
+		  }
+            else {
+				delta = 64;
+		  }
           break;
         case 2:
           delta = ((64 + (autoVibratoPos >> 1)) & 127) - 64;
@@ -154,8 +158,12 @@ package neoart.flod.fasttracker {
       if (period < portaPeriod) {
         glissPeriod += portaSpeed << 2;
 
-        if (!glissando) period = glissPeriod;
-          else period = Math.round(glissPeriod / 64) << 6;
+        if (!glissando) {
+			period = glissPeriod;
+		}
+          else {
+			  period = Math.round(glissPeriod / 64) << 6;
+		  }
 
         if (period >= portaPeriod) {
           period = portaPeriod;
@@ -164,8 +172,8 @@ package neoart.flod.fasttracker {
       } else if (period > portaPeriod) {
         glissPeriod -= portaSpeed << 2;
 
-        if (!glissando) period = glissPeriod;
-          else period = Math.round(glissPeriod / 64) << 6;
+        if (!glissando) {period = glissPeriod;}
+          else{ period = Math.round(glissPeriod / 64) << 6;}
 
         if (period <= portaPeriod) {
           period = portaPeriod;
@@ -229,8 +237,8 @@ package neoart.flod.fasttracker {
       flags |= F2Player.UPDATE_PERIOD;
     }
 
-    private static const
-      AUTOVIBRATO : Vector.<int> = Vector.<int>([
+    
+    private static const AUTOVIBRATO : Vector.<int> = Vector.<int>([
           0, -2, -3, -5, -6, -8, -9,-11,-12,-14,-16,-17,-19,-20,-22,-23,
         -24,-26,-27,-29,-30,-32,-33,-34,-36,-37,-38,-39,-41,-42,-43,-44,
         -45,-46,-47,-48,-49,-50,-51,-52,-53,-54,-55,-56,-56,-57,-58,-59,
@@ -246,9 +254,9 @@ package neoart.flod.fasttracker {
          64, 64, 64, 64, 64, 64, 63, 63, 63, 62, 62, 62, 61, 61, 60, 60,
          59, 59, 58, 57, 56, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46,
          45, 44, 43, 42, 41, 39, 38, 37, 36, 34, 33, 32, 30, 29, 27, 26,
-         24, 23, 22, 20, 19, 17, 16, 14, 12, 11,  9,  8,  6,  5,  3,  2]),
+         24, 23, 22, 20, 19, 17, 16, 14, 12, 11,  9,  8,  6,  5,  3,  2]);
 
-      VIBRATO : Vector.<int> = Vector.<int>([
+    private static const VIBRATO : Vector.<int> = Vector.<int>([
           0, 24, 49, 74, 97,120,141,161,180,197,212,224,235,244,250,253,
         255,253,250,244,235,224,212,197,180,161,141,120, 97, 74, 49, 24]);
   }

--- a/Flod Flash/src/neoart/flod/fred/FEPlayer.as
+++ b/Flod Flash/src/neoart/flod/fred/FEPlayer.as
@@ -20,14 +20,14 @@ package neoart.flod.fred {
   import neoart.flod.core.*;
 
   public final class FEPlayer extends AmigaPlayer {
-    private var
-      songs    : Vector.<FESong>,
-      samples  : Vector.<FESample>,
-      patterns : ByteArray,
-      song     : FESong,
-      voices   : Vector.<FEVoice>,
-      complete : int,
-      sampFlag : int;
+    
+    private var songs    : Vector.<FESong>;
+    private var samples  : Vector.<FESample>;
+    private var patterns : ByteArray;
+    private var song     : FESong;
+    private var voices   : Vector.<FEVoice>;
+    private var complete : int;
+    private var sampFlag : int;
 
     public function FEPlayer(amiga:Amiga = null) {
       super(amiga);
@@ -561,8 +561,11 @@ package neoart.flod.fred {
           stream.position = basePtr + pos;
           value = stream.readUnsignedShort();
 
-          if (j == 3 && (i == (len - 1))) size = tracksLen;
-            else size = stream.readUnsignedShort();
+          if (j == 3 && (i == (len - 1))) {
+		  size = tracksLen;}
+            else {
+				size = stream.readUnsignedShort();
+			}
 
           size = (size - value) >> 1;
           if (size > song.length) song.length = size;
@@ -585,8 +588,8 @@ package neoart.flod.fred {
       stream = null;
     }
 
-    private const
-      PERIODS : Vector.<int> = Vector.<int>([
+    
+    private const PERIODS : Vector.<int> = Vector.<int>([
         8192,7728,7296,6888,6504,6136,5792,5464,5160,
         4872,4600,4336,4096,3864,3648,3444,3252,3068,
         2896,2732,2580,2436,2300,2168,2048,1932,1824,

--- a/Flod Flash/src/neoart/flod/fred/FESample.as
+++ b/Flod Flash/src/neoart/flod/fred/FESample.as
@@ -18,37 +18,37 @@
 package neoart.flod.fred {
 
   public final class FESample {
-    internal var
-      pointer       : int,
-      loopPtr       : int,
-      length        : int,
-      relative      : int,
-      type          : int,
-      synchro       : int,
-      envelopeVol   : int,
-      attackSpeed   : int,
-      attackVol     : int,
-      decaySpeed    : int,
-      decayVol      : int,
-      sustainTime   : int,
-      releaseSpeed  : int,
-      releaseVol    : int,
-      arpeggio      : Vector.<int>,
-      arpeggioLimit : int,
-      arpeggioSpeed : int,
-      vibratoDelay  : int,
-      vibratoDepth  : int,
-      vibratoSpeed  : int,
-      pulseCounter  : int,
-      pulseDelay    : int,
-      pulsePosL     : int,
-      pulsePosH     : int,
-      pulseSpeed    : int,
-      pulseRateNeg  : int,
-      pulseRatePos  : int,
-      blendCounter  : int,
-      blendDelay    : int,
-      blendRate     : int;
+    
+    internal var pointer       : int;
+    internal var loopPtr       : int;
+    internal var length        : int;
+    internal var relative      : int;
+    internal var type          : int;
+    internal var synchro       : int;
+    internal var envelopeVol   : int;
+    internal var attackSpeed   : int;
+    internal var attackVol     : int;
+    internal var decaySpeed    : int;
+    internal var decayVol      : int;
+    internal var sustainTime   : int;
+    internal var releaseSpeed  : int;
+    internal var releaseVol    : int;
+    internal var arpeggio      : Vector.<int>;
+    internal var arpeggioLimit : int;
+    internal var arpeggioSpeed : int;
+    internal var vibratoDelay  : int;
+    internal var vibratoDepth  : int;
+    internal var vibratoSpeed  : int;
+    internal var pulseCounter  : int;
+    internal var pulseDelay    : int;
+    internal var pulsePosL     : int;
+    internal var pulsePosH     : int;
+    internal var pulseSpeed    : int;
+    internal var pulseRateNeg  : int;
+    internal var pulseRatePos  : int;
+    internal var blendCounter  : int;
+    internal var blendDelay    : int;
+    internal var blendRate     : int;
 
     public function FESample() {
       arpeggio = new Vector.<int>(16, true);

--- a/Flod Flash/src/neoart/flod/fred/FESong.as
+++ b/Flod Flash/src/neoart/flod/fred/FESong.as
@@ -18,10 +18,10 @@
 package neoart.flod.fred {
 
   public final class FESong {
-    internal var
-      speed  : int,
-      length : int,
-      tracks : Vector.<Vector.<int>>;
+    
+    internal var speed  : int;
+    internal var length : int;
+    internal var tracks : Vector.<Vector.<int>>;
 
     public function FESong() {
       tracks = new Vector.<Vector.<int>>(4, true);

--- a/Flod Flash/src/neoart/flod/fred/FEVoice.as
+++ b/Flod Flash/src/neoart/flod/fred/FEVoice.as
@@ -19,46 +19,46 @@ package neoart.flod.fred {
   import neoart.flod.core.*;
 
   public final class FEVoice {
-    internal var
-      index         : int,
-      bitFlag       : int,
-      next          : FEVoice,
-      channel       : AmigaChannel,
-      sample        : FESample,
-      trackPos      : int,
-      patternPos    : int,
-      tick          : int,
-      busy          : int,
-      synth         : int,
-      note          : int,
-      period        : int,
-      volume        : int,
-      envelopePos   : int,
-      sustainTime   : int,
-      arpeggioPos   : int,
-      arpeggioSpeed : int,
-      portamento    : int,
-      portaCounter  : int,
-      portaDelay    : int,
-      portaFlag     : int,
-      portaLimit    : int,
-      portaNote     : int,
-      portaPeriod   : int,
-      portaSpeed    : int,
-      vibrato       : int,
-      vibratoDelay  : int,
-      vibratoDepth  : int,
-      vibratoFlag   : int,
-      vibratoSpeed  : int,
-      pulseCounter  : int,
-      pulseDelay    : int,
-      pulseDir      : int,
-      pulsePos      : int,
-      pulseSpeed    : int,
-      blendCounter  : int,
-      blendDelay    : int,
-      blendDir      : int,
-      blendPos      : int;
+    
+    internal var index         : int;
+    internal var bitFlag       : int;
+    internal var next          : FEVoice;
+    internal var channel       : AmigaChannel;
+    internal var sample        : FESample;
+    internal var trackPos      : int;
+    internal var patternPos    : int;
+    internal var tick          : int;
+    internal var busy          : int;
+    internal var synth         : int;
+    internal var note          : int;
+    internal var period        : int;
+    internal var volume        : int;
+    internal var envelopePos   : int;
+    internal var sustainTime   : int;
+    internal var arpeggioPos   : int;
+    internal var arpeggioSpeed : int;
+    internal var portamento    : int;
+    internal var portaCounter  : int;
+    internal var portaDelay    : int;
+    internal var portaFlag     : int;
+    internal var portaLimit    : int;
+    internal var portaNote     : int;
+    internal var portaPeriod   : int;
+    internal var portaSpeed    : int;
+    internal var vibrato       : int;
+    internal var vibratoDelay  : int;
+    internal var vibratoDepth  : int;
+    internal var vibratoFlag   : int;
+    internal var vibratoSpeed  : int;
+    internal var pulseCounter  : int;
+    internal var pulseDelay    : int;
+    internal var pulseDir      : int;
+    internal var pulsePos      : int;
+    internal var pulseSpeed    : int;
+    internal var blendCounter  : int;
+    internal var blendDelay    : int;
+    internal var blendDir      : int;
+    internal var blendPos      : int;
 
     public function FEVoice(index:int, bitFlag:int) {
       this.index = index;

--- a/Flod Flash/src/neoart/flod/futurecomposer/FCPlayer.as
+++ b/Flod Flash/src/neoart/flod/futurecomposer/FCPlayer.as
@@ -20,14 +20,14 @@ package neoart.flod.futurecomposer {
   import neoart.flod.core.*;
 
   public final class FCPlayer extends AmigaPlayer {
-    private var
-      seqs    : ByteArray,
-      pats    : ByteArray,
-      vols    : ByteArray,
-      frqs    : ByteArray,
-      length  : int,
-      samples : Vector.<AmigaSample>,
-      voices  : Vector.<FCVoice>;
+    
+    private var seqs    : ByteArray;
+    private var pats    : ByteArray;
+    private var vols    : ByteArray;
+    private var frqs    : ByteArray;
+    private var length  : int;
+    private var samples : Vector.<AmigaSample>;
+    private var voices  : Vector.<FCVoice>;
 
     public function FCPlayer(amiga:Amiga = null) {
       super(amiga);
@@ -141,9 +141,10 @@ package neoart.flod.futurecomposer {
             switch (info) {
               case 0xe2:  //set wave
                 chan.enabled  = 0;
-                voice.enabled = 1
+                voice.enabled = 1;
                 voice.volCtr  = 1;
                 voice.volStep = 0;
+				break;
               case 0xe4:  //change wave:
                 sample = samples[frqs.readUnsignedByte()];
                 if (sample) {
@@ -284,9 +285,9 @@ package neoart.flod.futurecomposer {
 
         if (voice.portamentoFlag && voice.portamento) {
           if (voice.portamento > 0x1f)
-            voice.pitch += voice.portamento & 0x1f;
+            {voice.pitch += voice.portamento & 0x1f;}
           else
-            voice.pitch -= voice.portamento;
+            {voice.pitch -= voice.portamento;}
         }
         voice.pitchBendFlag ^= 1;
 
@@ -296,8 +297,8 @@ package neoart.flod.futurecomposer {
         }
         period += voice.pitch;
 
-        if (period < 113) period = 113;
-          else if (period > 3424) period = 3424;
+        if (period < 113) {period = 113;}
+          else if (period > 3424){ period = 3424;}
 
         chan.period = period;
         chan.volume = voice.volume;
@@ -341,9 +342,9 @@ package neoart.flod.futurecomposer {
       var i:int = 0, id:String, j:int, len:int, offset:int, position:int, sample:AmigaSample, size:int, temp:int, total:int;
       id = stream.readMultiByte(4, ENCODING);
 
-      if (id == "SMOD") version = FUTURECOMP_10;
-        else if (id == "FC14") version = FUTURECOMP_14;
-          else return;
+      if (id == "SMOD") {version = FUTURECOMP_10;}
+        else if (id == "FC14") {version = FUTURECOMP_14;}
+          else {return;}
 
       stream.position = 4;
       length = stream.readUnsignedInt();
@@ -505,9 +506,9 @@ package neoart.flod.futurecomposer {
       length *= 13;
     }
 
-    public static const
-      FUTURECOMP_10 = 1,
-      FUTURECOMP_14 = 2;
+   
+    public static const FUTURECOMP_10 :int  = 1;
+    public static const FUTURECOMP_14 :int = 2;
 
     private const
       PERIODS: Vector.<int> = Vector.<int>([
@@ -521,9 +522,9 @@ package neoart.flod.futurecomposer {
          856, 808, 762, 720, 678, 640, 604, 570, 538, 508, 480, 453,
          428, 404, 381, 360, 339, 320, 302, 285, 269, 254, 240, 226,
          214, 202, 190, 180, 170, 160, 151, 143, 135, 127, 120, 113,
-         113, 113, 113, 113, 113, 113, 113, 113, 113, 113, 113, 113]),
+         113, 113, 113, 113, 113, 113, 113, 113, 113, 113, 113, 113]);
 
-      WAVES: Vector.<int> = Vector.<int>([
+     private const WAVES: Vector.<int> = Vector.<int>([
           16,  16,  16,  16,  16,  16,  16,  16,  16,  16,  16,  16,  16,  16,  16,  16,
           16,  16,  16,  16,  16,  16,  16,  16,  16,  16,  16,  16,  16,  16,  16,  16,
            8,   8,   8,   8,   8,   8,   8,   8,  16,   8,  16,  16,   8,   8,  24, -64,

--- a/Flod Flash/src/neoart/flod/futurecomposer/FCVoice.as
+++ b/Flod Flash/src/neoart/flod/futurecomposer/FCVoice.as
@@ -19,41 +19,41 @@ package neoart.flod.futurecomposer {
   import neoart.flod.core.*;
 
   public final class FCVoice {
-    internal var
-      index          : int,
-      next           : FCVoice,
-      channel        : AmigaChannel,
-      sample         : AmigaSample,
-      enabled        : int,
-      pattern        : int,
-      soundTranspose : int,
-      transpose      : int,
-      patStep        : int,
-      frqStep        : int,
-      frqPos         : int,
-      frqSustain     : int,
-      frqTranspose   : int,
-      volStep        : int,
-      volPos         : int,
-      volCtr         : int,
-      volSpeed       : int,
-      volSustain     : int,
-      note           : int,
-      pitch          : int,
-      volume         : int,
-      pitchBendFlag  : int,
-      pitchBendSpeed : int,
-      pitchBendTime  : int,
-      portamentoFlag : int,
-      portamento     : int,
-      volBendFlag    : int,
-      volBendSpeed   : int,
-      volBendTime    : int,
-      vibratoFlag    : int,
-      vibratoSpeed   : int,
-      vibratoDepth   : int,
-      vibratoDelay   : int,
-      vibrato        : int;
+    
+    internal var index          : int;
+    internal var next           : FCVoice;
+    internal var channel        : AmigaChannel;
+    internal var sample         : AmigaSample;
+    internal var enabled        : int;
+    internal var pattern        : int;
+    internal var soundTranspose : int;
+    internal var transpose      : int;
+    internal var patStep        : int;
+    internal var frqStep        : int;
+    internal var frqPos         : int;
+    internal var frqSustain     : int;
+    internal var frqTranspose   : int;
+    internal var volStep        : int;
+    internal var volPos         : int;
+    internal var volCtr         : int;
+    internal var volSpeed       : int;
+    internal var volSustain     : int;
+    internal var note           : int;
+    internal var pitch          : int;
+    internal var volume         : int;
+    internal var pitchBendFlag  : int;
+    internal var pitchBendSpeed : int;
+    internal var pitchBendTime  : int;
+    internal var portamentoFlag : int;
+    internal var portamento     : int;
+    internal var volBendFlag    : int;
+    internal var volBendSpeed   : int;
+    internal var volBendTime    : int;
+    internal var vibratoFlag    : int;
+    internal var vibratoSpeed   : int;
+    internal var vibratoDepth   : int;
+    internal var vibratoDelay   : int;
+    internal var vibrato        : int;
 
     public function FCVoice(index:int) {
       this.index = index;

--- a/Flod Flash/src/neoart/flod/hippel/JHPlayer.as
+++ b/Flod Flash/src/neoart/flod/hippel/JHPlayer.as
@@ -20,20 +20,20 @@ package neoart.flod.hippel {
   import neoart.flod.core.*;
 
   public final class JHPlayer extends AmigaPlayer {
-    private var
-      songs       : Vector.<JHSong>,
-      samples     : Vector.<AmigaSample>,
-      stream      : ByteArray,
-      base        : int,
-      patterns    : int,
-      patternLen  : int,
-      periods     : int,
-      frqseqs     : int,
-      volseqs     : int,
-      samplesData : int,
-      song        : JHSong,
-      voices      : Vector.<JHVoice>,
-      coso        : int;
+    
+    private var songs       : Vector.<JHSong>;
+    private var samples     : Vector.<AmigaSample>;
+    private var stream      : ByteArray;
+    private var base        : int;
+    private var patterns    : int;
+    private var patternLen  : int;
+    private var  periods     : int;
+    private var  frqseqs     : int;
+    private var  volseqs     : int;
+    private var samplesData : int;
+    private var song        : JHSong;
+    private var voices      : Vector.<JHVoice>;
+    private var coso        : int;
 
     public function JHPlayer(amiga:Amiga = null) {
       super(amiga);

--- a/Flod Flash/src/neoart/flod/hippel/JHSong.as
+++ b/Flod Flash/src/neoart/flod/hippel/JHSong.as
@@ -18,9 +18,9 @@
 package neoart.flod.hippel {
 
   public final class JHSong {
-    internal var
-      pointer : int,
-      speed   : int,
-      length  : int;
+    
+    internal var pointer : int;
+    internal var speed   : int;
+    internal var length  : int;
   }
 }

--- a/Flod Flash/src/neoart/flod/hippel/JHVoice.as
+++ b/Flod Flash/src/neoart/flod/hippel/JHVoice.as
@@ -19,52 +19,52 @@ package neoart.flod.hippel {
   import neoart.flod.core.*;
 
   public final class JHVoice {
-    internal var
-      index       : int,
-      next        : JHVoice,
-      channel     : AmigaChannel,
-      enabled     : int,
-      cosoCounter : int,
-      cosoSpeed   : int,
-      trackPtr    : int,
-      trackPos    : int,
-      trackTransp : int,
-      patternPtr  : int,
-      patternPos  : int,
-      frqseqPtr   : int,
-      frqseqPos   : int,
-      volseqPtr   : int,
-      volseqPos   : int,
-      sample      : int,
-      loopPtr     : int,
-      repeat      : int,
-      tick        : int,
-      note        : int,
-      transpose   : int,
-      info        : int,
-      infoPrev    : int,
-      volume      : int,
-      volCounter  : int,
-      volSpeed    : int,
-      volSustain  : int,
-      volTransp   : int,
-      volFade     : int,
-      portaDelta  : int,
-      vibrato     : int,
-      vibDelay    : int,
-      vibDelta    : int,
-      vibDepth    : int,
-      vibSpeed    : int,
-      slide       : int,
-      sldActive   : int,
-      sldDone     : int,
-      sldCounter  : int,
-      sldSpeed    : int,
-      sldDelta    : int,
-      sldPointer  : int,
-      sldLen      : int,
-      sldEnd      : int,
-      sldLoopPtr  : int;
+    
+    internal var index       : int;
+    internal var next        : JHVoice;
+    internal var channel     : AmigaChannel;
+    internal var enabled     : int;
+    internal var cosoCounter : int;
+    internal var cosoSpeed   : int;
+    internal var trackPtr    : int;
+    internal var trackPos    : int;
+    internal var trackTransp : int;
+    internal var patternPtr  : int;
+    internal var patternPos  : int;
+    internal var frqseqPtr   : int;
+    internal var frqseqPos   : int;
+    internal var volseqPtr   : int;
+    internal var volseqPos   : int;
+    internal var sample      : int;
+    internal var loopPtr     : int;
+    internal var repeat      : int;
+    internal var tick        : int;
+    internal var note        : int;
+    internal var transpose   : int;
+    internal var info        : int;
+    internal var infoPrev    : int;
+    internal var volume      : int;
+    internal var volCounter  : int;
+    internal var volSpeed    : int;
+    internal var volSustain  : int;
+    internal var volTransp   : int;
+    internal var volFade     : int;
+    internal var portaDelta  : int;
+    internal var vibrato     : int;
+    internal var vibDelay    : int;
+    internal var vibDelta    : int;
+    internal var vibDepth    : int;
+    internal var vibSpeed    : int;
+    internal var slide       : int;
+    internal var sldActive   : int;
+    internal var sldDone     : int;
+    internal var sldCounter  : int;
+    internal var sldSpeed    : int;
+    internal var sldDelta    : int;
+    internal var sldPointer  : int;
+    internal var sldLen      : int;
+    internal var sldEnd      : int;
+    internal var sldLoopPtr  : int;
 
     public function JHVoice(index:int) {
       this.index = index;
@@ -75,7 +75,7 @@ package neoart.flod.hippel {
       enabled     = 0;
       cosoCounter = 0;
       cosoSpeed   = 0;
-      trackPtr    = 0
+      trackPtr    = 0;
       trackPos    = 12;
       trackTransp = 0;
       patternPtr  = 0;

--- a/Flod Flash/src/neoart/flod/hubbard/RHPlayer.as
+++ b/Flod Flash/src/neoart/flod/hubbard/RHPlayer.as
@@ -20,15 +20,15 @@ package neoart.flod.hubbard {
   import neoart.flod.core.*;
 
   public final class RHPlayer extends AmigaPlayer {
-    private var
-      songs    : Vector.<RHSong>,
-      samples  : Vector.<RHSample>,
-      song     : RHSong,
-      periods  : int,
-      vibrato  : int,
-      voices   : Vector.<RHVoice>,
-      stream   : ByteArray,
-      complete : int;
+    
+    private var songs    : Vector.<RHSong>;
+    private var samples  : Vector.<RHSample>;
+    private var song     : RHSong;
+    private var periods  : int;
+    private var vibrato  : int;
+    private var voices   : Vector.<RHVoice>;
+    private var stream   : ByteArray;
+    private var complete : int;
 
     public function RHPlayer(amiga:Amiga = null) {
       super(amiga);

--- a/Flod Flash/src/neoart/flod/hubbard/RHSample.as
+++ b/Flod Flash/src/neoart/flod/hubbard/RHSample.as
@@ -19,12 +19,12 @@ package neoart.flod.hubbard {
   import neoart.flod.core.*;
 
   public final class RHSample extends AmigaSample {
-    internal var
-      relative : int,
-      divider  : int,
-      vibrato  : int,
-      hiPos    : int,
-      loPos    : int,
-      wave     : Vector.<int>;
+    
+    internal var relative : int;
+    internal var divider  : int;
+    internal var vibrato  : int;
+    internal var hiPos    : int;
+    internal var loPos    : int;
+    internal var wave     : Vector.<int>;
   }
 }

--- a/Flod Flash/src/neoart/flod/hubbard/RHSong.as
+++ b/Flod Flash/src/neoart/flod/hubbard/RHSong.as
@@ -18,8 +18,8 @@
 package neoart.flod.hubbard {
 
   public final class RHSong {
-    internal var
-      speed  : int,
-      tracks : Vector.<int>;
+    
+    internal var speed  : int;
+    internal var tracks : Vector.<int>;
   }
 }

--- a/Flod Flash/src/neoart/flod/hubbard/RHVoice.as
+++ b/Flod Flash/src/neoart/flod/hubbard/RHVoice.as
@@ -19,25 +19,25 @@ package neoart.flod.hubbard {
   import neoart.flod.core.*;
 
   public final class RHVoice {
-    internal var
-      index      : int,
-      bitFlag    : int,
-      next       : RHVoice,
-      channel    : AmigaChannel,
-      sample     : RHSample,
-      trackPtr   : int,
-      trackPos   : int,
-      patternPos : int,
-      tick       : int,
-      busy       : int,
-      flags      : int,
-      note       : int,
-      period     : int,
-      volume     : int,
-      portaSpeed : int,
-      vibratoPtr : int,
-      vibratoPos : int,
-      synthPos   : int;
+    
+    internal var index      : int;
+    internal var bitFlag    : int;
+    internal var next       : RHVoice;
+    internal var channel    : AmigaChannel;
+    internal var sample     : RHSample;
+    internal var trackPtr   : int;
+    internal var trackPos   : int;
+    internal var patternPos : int;
+    internal var tick       : int;
+    internal var busy       : int;
+    internal var flags      : int;
+    internal var note       : int;
+    internal var period     : int;
+    internal var volume     : int;
+    internal var portaSpeed : int;
+    internal var vibratoPtr : int;
+    internal var vibratoPos : int;
+    internal var synthPos   : int;
 
     public function RHVoice(index:int, bitFlag:int) {
       this.index = index;

--- a/Flod Flash/src/neoart/flod/sidmon/S1Player.as
+++ b/Flod Flash/src/neoart/flod/sidmon/S1Player.as
@@ -20,40 +20,40 @@ package neoart.flod.sidmon {
   import neoart.flod.core.*;
 
   public final class S1Player extends AmigaPlayer {
-    private var
-      tracksPtr   : Vector.<int>,
-      tracks      : Vector.<AmigaStep>,
-      patternsPtr : Vector.<int>,
-      patterns    : Vector.<SMRow>,
-      samples     : Vector.<S1Sample>,
-      waveLists   : Vector.<int>,
-      speedDef    : int,
-      trackLen    : int,
-      patternDef  : int,
-      mix1Speed   : int,
-      mix2Speed   : int,
-      mix1Dest    : int,
-      mix2Dest    : int,
-      mix1Source1 : int,
-      mix1Source2 : int,
-      mix2Source1 : int,
-      mix2Source2 : int,
-      doFilter    : int,
-      doReset     : int,
-      voices      : Vector.<S1Voice>,
-      trackPos    : int,
-      trackEnd    : int,
-      patternPos  : int,
-      patternEnd  : int,
-      patternLen  : int,
-      mix1Ctr     : int,
-      mix2Ctr     : int,
-      mix1Pos     : int,
-      mix2Pos     : int,
-      audPtr      : int,
-      audLen      : int,
-      audPer      : int,
-      audVol      : int;
+    
+    private var tracksPtr   : Vector.<int>;
+    private var tracks      : Vector.<AmigaStep>;
+    private var patternsPtr : Vector.<int>;
+    private var patterns    : Vector.<SMRow>;
+    private var samples     : Vector.<S1Sample>;
+    private var waveLists   : Vector.<int>;
+    private var speedDef    : int;
+    private var trackLen    : int;
+    private var patternDef  : int;
+    private var mix1Speed   : int;
+    private var mix2Speed   : int;
+    private var mix1Dest    : int;
+    private var mix2Dest    : int;
+    private var mix1Source1 : int;
+    private var mix1Source2 : int;
+    private var mix2Source1 : int;
+    private var mix2Source2 : int;
+    private var doFilter    : int;
+    private var doReset     : int;
+    private var voices      : Vector.<S1Voice>;
+    private var trackPos    : int;
+    private var trackEnd    : int;
+    private var patternPos  : int;
+    private var patternEnd  : int;
+    private var patternLen  : int;
+    private var mix1Ctr     : int;
+    private var mix2Ctr     : int;
+    private var mix1Pos     : int;
+    private var mix2Pos     : int;
+    private var audPtr      : int;
+    private var audLen      : int;
+    private var audPer      : int;
+    private var audVol      : int;
 
     public function S1Player(amiga:Amiga = null) {
       super(amiga);
@@ -78,8 +78,13 @@ package neoart.flod.sidmon {
 
         if (tick == 0) {
           if (patternEnd) {
-            if (trackEnd) voice.step = tracksPtr[voice.index];
-              else voice.step++;
+            if (trackEnd) {
+			voice.step = tracksPtr[voice.index];
+			
+			}
+              else {
+				  voice.step++;
+			  }
 
             step = tracks[voice.step];
             voice.row = patternsPtr[step.pattern];
@@ -260,8 +265,8 @@ package neoart.flod.sidmon {
         if (audPer != 0) chan.period  = voice.period;
         if (audLen != 0) chan.length  = audLen;
 
-        if (sample.volume) chan.volume = sample.volume;
-          else chan.volume = audVol >> 2;
+        if (sample.volume) {chan.volume = sample.volume;}
+          else {chan.volume = audVol >> 2;}
 
         chan.enabled = 1;
         voice = voice.next;
@@ -379,9 +384,9 @@ package neoart.flod.sidmon {
         start = stream.readUnsignedShort();
 
         if (start == 0xffd4) {
-          if (j == 0x0fec) ver = SIDMON_0FFA;
-            else if (j == 0x1466) ver = SIDMON_1444;
-              else ver = j;
+          if (j == 0x0fec) {ver = SIDMON_0FFA;}
+            else if (j == 0x1466) {ver = SIDMON_1444;}
+              else{ ver = j;}
 
           position = j + stream.position - 6;
           break;
@@ -602,8 +607,8 @@ package neoart.flod.sidmon {
               sample.length = sample.loop + sample.repeat;
 
             sample.pointer = amiga.store(stream, sample.length, data + sample.pointer);
-            if (sample.repeat < 6 || sample.loop == 0) sample.loopPtr = 0;
-              else sample.loopPtr = sample.pointer + sample.loop;
+            if (sample.repeat < 6 || sample.loop == 0) {sample.loopPtr = 0;}
+              else {sample.loopPtr = sample.pointer + sample.loop;}
 
             stream.position = j;
           }
@@ -646,18 +651,18 @@ package neoart.flod.sidmon {
       version = 1;
     }
 
-    private const
-      SIDMON_0FFA = 0x0ffa,
-      SIDMON_1170 = 0x1170,
-      SIDMON_11C6 = 0x11c6,
-      SIDMON_11DC = 0x11dc,
-      SIDMON_11E0 = 0x11e0,
-      SIDMON_125A = 0x125a,
-      SIDMON_1444 = 0x1444,
+    
+    private const SIDMON_0FFA :int = 0x0ffa;
+    private const SIDMON_1170 :int = 0x1170;
+    private const SIDMON_11C6 :int = 0x11c6;
+    private const SIDMON_11DC :int = 0x11dc;
+    private const SIDMON_11E0 :int = 0x11e0;
+    private const SIDMON_125A :int = 0x125a;
+    private const SIDMON_1444 :int = 0x1444;
 
-      EMBEDDED: Vector.<int> = Vector.<int>([1166, 408, 908]),
+    private const EMBEDDED: Vector.<int> = Vector.<int>([1166, 408, 908]);
 
-      PERIODS: Vector.<int> = Vector.<int>([0,
+    private const PERIODS: Vector.<int> = Vector.<int>([0,
         5760,5424,5120,4832,4560,4304,4064,3840,3616,3424,3232,3048,
         2880,2712,2560,2416,2280,2152,2032,1920,1808,1712,1616,1524,
         1440,1356,1280,1208,1140,1076,1016, 960, 904, 856, 808, 762,

--- a/Flod Flash/src/neoart/flod/sidmon/S1Sample.as
+++ b/Flod Flash/src/neoart/flod/sidmon/S1Sample.as
@@ -19,20 +19,20 @@ package neoart.flod.sidmon {
   import neoart.flod.core.*;
 
   public final class S1Sample extends AmigaSample {
-    internal var
-      waveform     : int,
-      arpeggio     : Vector.<int>,
-      attackSpeed  : int,
-      attackMax    : int,
-      decaySpeed   : int,
-      decayMin     : int,
-      sustain      : int,
-      releaseSpeed : int,
-      releaseMin   : int,
-      phaseShift   : int,
-      phaseSpeed   : int,
-      finetune     : int,
-      pitchFall    : int;
+    
+    internal var waveform     : int;
+    internal var arpeggio     : Vector.<int>;
+    internal var attackSpeed  : int;
+    internal var attackMax    : int;
+    internal var decaySpeed   : int;
+    internal var decayMin     : int;
+    internal var sustain      : int;
+    internal var releaseSpeed : int;
+    internal var releaseMin   : int;
+    internal var phaseShift   : int;
+    internal var phaseSpeed   : int;
+    internal var finetune     : int;
+    internal var pitchFall    : int;
 
     public function S1Sample() {
       arpeggio = new Vector.<int>(16, true);

--- a/Flod Flash/src/neoart/flod/sidmon/S1Voice.as
+++ b/Flod Flash/src/neoart/flod/sidmon/S1Voice.as
@@ -19,32 +19,32 @@ package neoart.flod.sidmon {
   import neoart.flod.core.*;
 
   public final class S1Voice {
-    internal var
-      index        : int,
-      next         : S1Voice,
-      channel      : AmigaChannel,
-      step         : int,
-      row          : int,
-      sample       : int,
-      samplePtr    : int,
-      sampleLen    : int,
-      note         : int,
-      noteTimer    : int,
-      period       : int,
-      volume       : int,
-      bendTo       : int,
-      bendSpeed    : int,
-      arpeggioCtr  : int,
-      envelopeCtr  : int,
-      pitchCtr     : int,
-      pitchFallCtr : int,
-      sustainCtr   : int,
-      phaseTimer   : int,
-      phaseSpeed   : int,
-      wavePos      : int,
-      waveList     : int,
-      waveTimer    : int,
-      waitCtr      : int;
+    
+    internal var index        : int;
+    internal var next         : S1Voice;
+    internal var channel      : AmigaChannel;
+    internal var step         : int;
+    internal var row          : int;
+    internal var sample       : int;
+    internal var samplePtr    : int;
+    internal var sampleLen    : int;
+    internal var note         : int;
+    internal var noteTimer    : int;
+    internal var period       : int;
+    internal var volume       : int;
+    internal var bendTo       : int;
+    internal var bendSpeed    : int;
+    internal var arpeggioCtr  : int;
+    internal var envelopeCtr  : int;
+    internal var pitchCtr     : int;
+    internal var pitchFallCtr : int;
+    internal var sustainCtr   : int;
+    internal var phaseTimer   : int;
+    internal var phaseSpeed   : int;
+    internal var wavePos      : int;
+    internal var waveList     : int;
+    internal var waveTimer    : int;
+    internal var waitCtr      : int;
 
     public function S1Voice(index:int) {
       this.index = index;

--- a/Flod Flash/src/neoart/flod/sidmon/S2Instrument.as
+++ b/Flod Flash/src/neoart/flod/sidmon/S2Instrument.as
@@ -19,27 +19,27 @@ package neoart.flod.sidmon {
   import neoart.flod.core.*;
 
   public final class S2Instrument {
-    internal var
-      wave           : int,
-      waveLen        : int,
-      waveDelay      : int,
-      waveSpeed      : int,
-      arpeggio       : int,
-      arpeggioLen    : int,
-      arpeggioDelay  : int,
-      arpeggioSpeed  : int,
-      vibrato        : int,
-      vibratoLen     : int,
-      vibratoDelay   : int,
-      vibratoSpeed   : int,
-      pitchBend      : int,
-      pitchBendDelay : int,
-      attackMax      : int,
-      attackSpeed    : int,
-      decayMin       : int,
-      decaySpeed     : int,
-      sustain        : int,
-      releaseMin     : int,
-      releaseSpeed   : int;
+    
+    internal var wave           : int;
+    internal var waveLen        : int;
+    internal var waveDelay      : int;
+    internal var waveSpeed      : int;
+    internal var arpeggio       : int;
+    internal var arpeggioLen    : int;
+    internal var arpeggioDelay  : int;
+    internal var arpeggioSpeed  : int;
+    internal var vibrato        : int;
+    internal var vibratoLen     : int;
+    internal var vibratoDelay   : int;
+    internal var vibratoSpeed   : int;
+    internal var pitchBend      : int;
+    internal var pitchBendDelay : int;
+    internal var attackMax      : int;
+    internal var attackSpeed    : int;
+    internal var decayMin       : int;
+    internal var decaySpeed     : int;
+    internal var sustain        : int;
+    internal var releaseMin     : int;
+    internal var releaseSpeed   : int;
   }
 }

--- a/Flod Flash/src/neoart/flod/sidmon/S2Player.as
+++ b/Flod Flash/src/neoart/flod/sidmon/S2Player.as
@@ -20,22 +20,22 @@ package neoart.flod.sidmon {
   import neoart.flod.core.*;
 
   public final class S2Player extends AmigaPlayer {
-    private var
-      tracks      : Vector.<S2Step>,
-      patterns    : Vector.<SMRow>,
-      instruments : Vector.<S2Instrument>,
-      samples     : Vector.<S2Sample>,
-      arpeggios   : Vector.<int>,
-      vibratos    : Vector.<int>,
-      waves       : Vector.<int>,
-      length      : int,
-      speedDef    : int,
-      voices      : Vector.<S2Voice>,
-      trackPos    : int,
-      patternPos  : int,
-      patternLen  : int,
-      arpeggioFx  : Vector.<int>,
-      arpeggioPos : int;
+    
+    private var tracks      : Vector.<S2Step>;
+    private var patterns    : Vector.<SMRow>;
+    private var instruments : Vector.<S2Instrument>;
+    private var samples     : Vector.<S2Sample>;
+    private var arpeggios   : Vector.<int>;
+    private var vibratos    : Vector.<int>;
+    private var waves       : Vector.<int>;
+    private var length      : int;
+    private var speedDef    : int;
+    private var voices      : Vector.<S2Voice>;
+    private var trackPos    : int;
+    private var patternPos  : int;
+    private var patternLen  : int;
+    private var arpeggioFx  : Vector.<int>;
+    private var arpeggioPos : int;
 
     public function S2Player(amiga:Amiga = null) {
       super(amiga);
@@ -199,8 +199,8 @@ package neoart.flod.sidmon {
             }
             break;
           case 2:   //sustain
-            if (voice.sustainCtr == instr.sustain) voice.adsrPos--;
-              else voice.sustainCtr++;
+            if (voice.sustainCtr == instr.sustain) {voice.adsrPos--;}
+              else {voice.sustainCtr++;}
             break;
           case 1:   //release
             voice.volume -= instr.releaseSpeed;
@@ -215,26 +215,26 @@ package neoart.flod.sidmon {
         if (instr.waveLen) {
           if (voice.waveCtr == instr.waveDelay) {
             voice.waveCtr = instr.waveDelay - instr.waveSpeed;
-            if (voice.wavePos == instr.waveLen) voice.wavePos = 0;
-              else voice.wavePos++;
+            if (voice.wavePos == instr.waveLen) {voice.wavePos = 0;}
+              else {voice.wavePos++;}
 
             voice.sample = sample = samples[waves[int(instr.wave + voice.wavePos)]];
             chan.pointer = sample.pointer;
             chan.length  = sample.length;
           } else
-            voice.waveCtr++;
+            {voice.waveCtr++;}
         }
 
         if (instr.arpeggioLen) {
           if (voice.arpeggioCtr == instr.arpeggioDelay) {
             voice.arpeggioCtr = instr.arpeggioDelay - instr.arpeggioSpeed;
-            if (voice.arpeggioPos == instr.arpeggioLen) voice.arpeggioPos = 0;
-              else voice.arpeggioPos++;
+            if (voice.arpeggioPos == instr.arpeggioLen) {voice.arpeggioPos = 0;}
+              else {voice.arpeggioPos++;}
 
             value = voice.original + arpeggios[int(instr.arpeggio + voice.arpeggioPos)];
             voice.period = PERIODS[value];
           } else
-            voice.arpeggioCtr++;
+            {voice.arpeggioCtr++;}
         }
         row = voice.row;
 
@@ -293,8 +293,8 @@ package neoart.flod.sidmon {
         if (instr.vibratoLen) {
           if (voice.vibratoCtr == instr.vibratoDelay) {
             voice.vibratoCtr = instr.vibratoDelay - instr.vibratoSpeed;
-            if (voice.vibratoPos == instr.vibratoLen) voice.vibratoPos = 0;
-              else voice.vibratoPos++;
+            if (voice.vibratoPos == instr.vibratoLen) {voice.vibratoPos = 0;}
+              else {voice.vibratoPos++;}
 
             voice.period += vibratos[int(instr.vibrato + voice.vibratoPos)];
           } else
@@ -329,8 +329,8 @@ package neoart.flod.sidmon {
 
         voice.period += voice.pitchBend;
 
-        if (voice.period < 95) voice.period = 95;
-          else if (voice.period > 5760) voice.period = 5760;
+        if (voice.period < 95) {voice.period = 95}
+          else if (voice.period > 5760) {voice.period = 5760}
 
         chan.period = voice.period;
         voice = voice.next;

--- a/Flod Flash/src/neoart/flod/sidmon/S2Sample.as
+++ b/Flod Flash/src/neoart/flod/sidmon/S2Sample.as
@@ -19,14 +19,14 @@ package neoart.flod.sidmon {
   import neoart.flod.core.*;
 
   public final class S2Sample extends AmigaSample {
-    internal var
-      negStart  : int,
-      negLen    : int,
-      negSpeed  : int,
-      negDir    : int,
-      negOffset : int,
-      negPos    : int,
-      negCtr    : int,
-      negToggle : int;
+    
+    internal var negStart  : int;
+    internal var negLen    : int;
+    internal var negSpeed  : int;
+    internal var negDir    : int;
+    internal var negOffset : int;
+    internal var negPos    : int;
+    internal var negCtr    : int;
+    internal var negToggle : int;
   }
 }

--- a/Flod Flash/src/neoart/flod/sidmon/S2Step.as
+++ b/Flod Flash/src/neoart/flod/sidmon/S2Step.as
@@ -19,7 +19,7 @@ package neoart.flod.sidmon {
   import neoart.flod.core.*;
 
   public final class S2Step extends AmigaStep {
-    internal var
-      soundTranspose : int;
+    
+    internal var soundTranspose : int;
   }
 }

--- a/Flod Flash/src/neoart/flod/sidmon/S2Voice.as
+++ b/Flod Flash/src/neoart/flod/sidmon/S2Voice.as
@@ -19,34 +19,34 @@ package neoart.flod.sidmon {
   import neoart.flod.core.*;
 
   public final class S2Voice {
-    internal var
-      index          : int,
-      next           : S2Voice,
-      channel        : AmigaChannel,
-      step           : S2Step,
-      row            : SMRow,
-      instr          : S2Instrument,
-      sample         : S2Sample,
-      enabled        : int,
-      pattern        : int,
-      instrument     : int,
-      note           : int,
-      period         : int,
-      volume         : int,
-      original       : int,
-      adsrPos        : int,
-      sustainCtr     : int,
-      pitchBend      : int,
-      pitchBendCtr   : int,
-      noteSlideTo    : int,
-      noteSlideSpeed : int,
-      waveCtr        : int,
-      wavePos        : int,
-      arpeggioCtr    : int,
-      arpeggioPos    : int,
-      vibratoCtr     : int,
-      vibratoPos     : int,
-      speed          : int;
+    
+    internal var index          : int;
+    internal var next           : S2Voice;
+    internal var channel        : AmigaChannel;
+    internal var step           : S2Step;
+    internal var row            : SMRow;
+    internal var instr          : S2Instrument;
+    internal var sample         : S2Sample;
+    internal var enabled        : int;
+    internal var pattern        : int;
+    internal var instrument     : int;
+    internal var note           : int;
+    internal var period         : int;
+    internal var volume         : int;
+    internal var original       : int;
+    internal var adsrPos        : int;
+    internal var sustainCtr     : int;
+    internal var pitchBend      : int;
+    internal var pitchBendCtr   : int;
+    internal var noteSlideTo    : int;
+    internal var noteSlideSpeed : int;
+    internal var waveCtr        : int;
+    internal var wavePos        : int;
+    internal var arpeggioCtr    : int;
+    internal var arpeggioPos    : int;
+    internal var vibratoCtr     : int;
+    internal var vibratoPos     : int;
+    internal var speed          : int;
 
     public function S2Voice(index:int) {
       this.index = index;

--- a/Flod Flash/src/neoart/flod/sidmon/SMRow.as
+++ b/Flod Flash/src/neoart/flod/sidmon/SMRow.as
@@ -19,7 +19,6 @@ package neoart.flod.sidmon {
   import neoart.flod.core.*;
 
   public final class SMRow extends AmigaRow {
-    internal var
-      speed : int;
+    internal var speed : int;
   }
 }

--- a/Flod Flash/src/neoart/flod/soundfx/FXPlayer.as
+++ b/Flod Flash/src/neoart/flod/soundfx/FXPlayer.as
@@ -20,16 +20,16 @@ package neoart.flod.soundfx {
   import neoart.flod.core.*;
 
   public final class FXPlayer extends AmigaPlayer {
-    private var
-      track      : Vector.<int>,
-      patterns   : Vector.<AmigaRow>,
-      samples    : Vector.<AmigaSample>,
-      length     : int,
-      voices     : Vector.<FXVoice>,
-      trackPos   : int,
-      patternPos : int,
-      jumpFlag   : int,
-      delphine   : int;
+    
+    private var track      : Vector.<int>;
+    private var patterns   : Vector.<AmigaRow>;
+    private var samples    : Vector.<AmigaSample>;
+    private var length     : int;
+    private var voices     : Vector.<FXVoice>;
+    private var trackPos   : int;
+    private var patternPos : int;
+    private var jumpFlag   : int;
+    private var delphine   : int;
 
     public function FXPlayer(amiga:Amiga = null) {
       super(amiga);
@@ -46,9 +46,9 @@ package neoart.flod.soundfx {
 
     override public function set force(value:int):void {
       if (value < SOUNDFX_10)
-        value = SOUNDFX_10;
+       { value = SOUNDFX_10;}
       else if (value > SOUNDFX_20)
-        value = SOUNDFX_20;
+       { value = SOUNDFX_20;}
 
       version = value;
     }
@@ -85,11 +85,11 @@ package neoart.flod.soundfx {
             voice.volume = sample.volume;
 
             if (voice.effect == 5)
-              voice.volume += voice.param;
+             { voice.volume += voice.param;}
             else if (voice.effect == 6)
-              voice.volume -= voice.param;
+              {voice.volume -= voice.param;
 
-            chan.volume = voice.volume;
+			  chan.volume = voice.volume;}
           } else {
             sample = voice.sample;
           }
@@ -115,8 +115,8 @@ package neoart.flod.soundfx {
                 chan.pointer = sample.pointer;
                 chan.length  = sample.length;
 
-                if (delphine) chan.period = voice.period << 1;
-                  else chan.period  = voice.period;
+                if (delphine) {chan.period = voice.period << 1;}
+                  else {chan.period  = voice.period;}
                 break;
             }
 
@@ -194,16 +194,16 @@ package neoart.flod.soundfx {
                   continue;
                 }
 
-                if (value == 1) value = voice.param & 0x0f;
-                  else value = voice.param >> 4;
+                if (value == 1) {value = voice.param & 0x0f;}
+                  else {value = voice.param >> 4;}
 
                 while (voice.last != PERIODS[index]) index++;
                 chan.period = PERIODS[int(index + value)];
                 break;
               case 2:   //pitchbend
                 value = voice.param >> 4;
-                if (value) voice.period += value;
-                  else voice.period -= voice.param & 0x0f;
+                if (value) {voice.period += value;}
+                  else {voice.period -= voice.param & 0x0f;}
                 chan.period = voice.period;
                 break;
               case 3:   //filter on
@@ -214,6 +214,7 @@ package neoart.flod.soundfx {
                 break;
               case 8:   //step down
                 value = -1;
+				break;
               case 7:   //step up
                 voice.stepSpeed  = voice.param & 0x0f;
                 voice.stepPeriod = version > SOUNDFX_18 ? voice.last : voice.period;
@@ -386,7 +387,9 @@ package neoart.flod.soundfx {
         if (sample == null) continue;
 
         if (sample.loop)
-          sample.loopPtr = sample.pointer + sample.loop;
+         {
+			sample.loopPtr = sample.pointer + sample.loop;
+		 }
         else {
           sample.loopPtr = amiga.memory.length;
           sample.repeat  = 2;
@@ -423,11 +426,11 @@ package neoart.flod.soundfx {
       }
     }
 
-    public static const
-      SOUNDFX_10 = 1,
-      SOUNDFX_18 = 2,
-      SOUNDFX_19 = 3,
-      SOUNDFX_20 = 4;
+    
+    public static const  SOUNDFX_10 :int = 1;
+    public static const  SOUNDFX_18 :int = 2;
+     public static const SOUNDFX_19 :int = 3;
+     public static const SOUNDFX_20 :int = 4;
 
     private const
       PERIODS: Vector.<int> = Vector.<int>([

--- a/Flod Flash/src/neoart/flod/soundfx/FXVoice.as
+++ b/Flod Flash/src/neoart/flod/soundfx/FXVoice.as
@@ -19,25 +19,25 @@ package neoart.flod.soundfx {
   import neoart.flod.core.*;
 
   public final class FXVoice {
-    internal var
-      index       : int,
-      next        : FXVoice,
-      channel     : AmigaChannel,
-      sample      : AmigaSample,
-      enabled     : int,
-      period      : int,
-      effect      : int,
-      param       : int,
-      volume      : int,
-      last        : int,
-      slideCtr    : int,
-      slideDir    : int,
-      slideParam  : int,
-      slidePeriod : int,
-      slideSpeed  : int,
-      stepPeriod  : int,
-      stepSpeed   : int,
-      stepWanted  : int;
+    
+    internal var index       : int;
+    internal var next        : FXVoice;
+    internal var channel     : AmigaChannel;
+    internal var sample      : AmigaSample;
+    internal var enabled     : int;
+    internal var period      : int;
+    internal var effect      : int;
+    internal var param       : int;
+    internal var volume      : int;
+    internal var last        : int;
+    internal var slideCtr    : int;
+    internal var slideDir    : int;
+    internal var slideParam  : int;
+    internal var slidePeriod : int;
+    internal var slideSpeed  : int;
+    internal var stepPeriod  : int;
+    internal var stepSpeed   : int;
+    internal var stepWanted  : int;
 
     public function FXVoice(index:int) {
       this.index = index;

--- a/Flod Flash/src/neoart/flod/soundmon/BPPlayer.as
+++ b/Flod Flash/src/neoart/flod/soundmon/BPPlayer.as
@@ -20,20 +20,20 @@ package neoart.flod.soundmon {
   import neoart.flod.core.*;
 
   public final class BPPlayer extends AmigaPlayer {
-    private var
-      tracks      : Vector.<BPStep>,
-      patterns    : Vector.<AmigaRow>,
-      samples     : Vector.<BPSample>,
-      length      : int,
-      buffer      : Vector.<int>,
-      voices      : Vector.<BPVoice>,
-      trackPos    : int,
-      patternPos  : int,
-      nextPos     : int,
-      jumpFlag    : int,
-      repeatCtr   : int,
-      arpeggioCtr : int,
-      vibratoPos  : int;
+    
+    private var tracks      : Vector.<BPStep>;
+    private var patterns    : Vector.<AmigaRow>;
+    private var samples     : Vector.<BPSample>;
+    private var length      : int;
+    private var buffer      : Vector.<int>;
+    private var voices      : Vector.<BPVoice>;
+    private var trackPos    : int;
+    private var patternPos  : int;
+    private var nextPos     : int;
+    private var jumpFlag    : int;
+    private var repeatCtr   : int;
+    private var arpeggioCtr : int;
+    private var vibratoPos  : int;
 
     public function BPPlayer(amiga:Amiga = null) {
       super(amiga);
@@ -59,8 +59,12 @@ package neoart.flod.soundmon {
         chan = voice.channel;
         voice.period += voice.autoSlide;
 
-        if (voice.vibrato) chan.period = voice.period + (VIBRATO[vibratoPos] / voice.vibrato);
-          else chan.period = voice.period;
+        if (voice.vibrato) {
+			chan.period = voice.period + (VIBRATO[vibratoPos] / voice.vibrato);
+		}
+          else {
+			  chan.period = voice.period;
+		  }
 
         chan.pointer = voice.samplePtr;
         chan.length  = voice.sampleLen;
@@ -69,9 +73,9 @@ package neoart.flod.soundmon {
           note = voice.note;
 
           if (!arpeggioCtr)
-            note += ((voice.arpeggio & 0xf0) >> 4) + ((voice.autoArpeggio & 0xf0) >> 4);
+            {note += ((voice.arpeggio & 0xf0) >> 4) + ((voice.autoArpeggio & 0xf0) >> 4);}
           else if (arpeggioCtr == 1)
-            note += (voice.arpeggio & 0x0f) + (voice.autoArpeggio & 0x0f);
+           { note += (voice.arpeggio & 0x0f) + (voice.autoArpeggio & 0x0f);}
 
           chan.period = voice.period = PERIODS[int(note + 35)];
           voice.restart = 0;
@@ -247,8 +251,8 @@ package neoart.flod.soundmon {
             voice.note = note;
             voice.period = PERIODS[int(note + 35)];
 
-            if (option < 13) voice.restart = voice.volumeDef = 1;
-              else voice.restart = 0;
+            if (option < 13) {voice.restart = voice.volumeDef = 1;}
+              else{voice.restart = 0;}
 
             instr = row.sample;
             if (instr == 0) instr = voice.sample;
@@ -286,8 +290,8 @@ package neoart.flod.soundmon {
               voice.arpeggio = 0;
               break;
             case 6:   //set vibrato
-              if (version == BPSOUNDMON_V3) voice.vibrato = data;
-                else repeatCtr = data;
+              if (version == BPSOUNDMON_V3) {voice.vibrato = data;}
+                else {repeatCtr = data;}
               break;
             case 7:   //step jump
               if (version == BPSOUNDMON_V3) {
@@ -484,9 +488,9 @@ package neoart.flod.soundmon {
         version = BPSOUNDMON_V1;
       } else {
         id = id.substr(0, 3);
-        if (id == "V.2") version = BPSOUNDMON_V2;
-          else if (id == "V.3") version = BPSOUNDMON_V3;
-            else return;
+        if (id == "V.2") {version = BPSOUNDMON_V2;}
+          else if (id == "V.3") {version = BPSOUNDMON_V3;}
+            else {return;}
 
         stream.position = 29;
         tables = stream.readUnsignedByte();
@@ -602,21 +606,20 @@ package neoart.flod.soundmon {
       }
     }
 
-    public static const
-      BPSOUNDMON_V1 = 1,
-      BPSOUNDMON_V2 = 2,
-      BPSOUNDMON_V3 = 3;
+    private const BPSOUNDMON_V1 :int = 1;
+    private const BPSOUNDMON_V2 :int = 2;
+    private const BPSOUNDMON_V3 :int = 3;
 
-    private const
-      PERIODS: Vector.<int> = Vector.<int>([
+    
+    private const PERIODS: Vector.<int> = Vector.<int>([
         6848,6464,6080,5760,5440,5120,4832,4576,4320,4064,3840,3616,
         3424,3232,3040,2880,2720,2560,2416,2288,2160,2032,1920,1808,
         1712,1616,1520,1440,1360,1280,1208,1144,1080,1016, 960, 904,
          856, 808, 760, 720, 680, 640, 604, 572, 540, 508, 480, 452,
          428, 404, 380, 360, 340, 320, 302, 286, 270, 254, 240, 226,
          214, 202, 190, 180, 170, 160, 151, 143, 135, 127, 120, 113,
-         107, 101,  95,  90,  85,  80,  76,  72,  68,  64,  60,  57]),
+         107, 101,  95,  90,  85,  80,  76,  72,  68,  64,  60,  57]);
 
-      VIBRATO: Vector.<int> = Vector.<int>([0,64,128,64,0,-64,-128,-64]);
+     private const VIBRATO: Vector.<int> = Vector.<int>([0,64,128,64,0,-64,-128,-64]);
   }
 }

--- a/Flod Flash/src/neoart/flod/soundmon/BPSample.as
+++ b/Flod Flash/src/neoart/flod/soundmon/BPSample.as
@@ -19,31 +19,31 @@ package neoart.flod.soundmon {
   import neoart.flod.core.*;
 
   public final class BPSample extends AmigaSample {
-    internal var
-      synth       : int,
-      table       : int,
-      adsrControl : int,
-      adsrTable   : int,
-      adsrLen     : int,
-      adsrSpeed   : int,
-      lfoControl  : int,
-      lfoTable    : int,
-      lfoDepth    : int,
-      lfoLen      : int,
-      lfoDelay    : int,
-      lfoSpeed    : int,
-      egControl   : int,
-      egTable     : int,
-      egLen       : int,
-      egDelay     : int,
-      egSpeed     : int,
-      fxControl   : int,
-      fxDelay     : int,
-      fxSpeed     : int,
-      modControl  : int,
-      modTable    : int,
-      modLen      : int,
-      modDelay    : int,
-      modSpeed    : int;
+    
+    internal var synth       : int;
+    internal var table       : int;
+    internal var adsrControl : int;
+    internal var adsrTable   : int;
+    internal var adsrLen     : int;
+    internal var adsrSpeed   : int;
+    internal var lfoControl  : int;
+    internal var lfoTable    : int;
+    internal var lfoDepth    : int;
+    internal var lfoLen      : int;
+    internal var lfoDelay    : int;
+    internal var lfoSpeed    : int;
+    internal var egControl   : int;
+    internal var egTable     : int;
+    internal var egLen       : int;
+    internal var egDelay     : int;
+    internal var egSpeed     : int;
+    internal var fxControl   : int;
+    internal var fxDelay     : int;
+    internal var fxSpeed     : int;
+    internal var modControl  : int;
+    internal var modTable    : int;
+    internal var modLen      : int;
+    internal var modDelay    : int;
+    internal var modSpeed    : int;
   }
 }

--- a/Flod Flash/src/neoart/flod/soundmon/BPStep.as
+++ b/Flod Flash/src/neoart/flod/soundmon/BPStep.as
@@ -19,7 +19,6 @@ package neoart.flod.soundmon {
   import neoart.flod.core.*;
 
   public final class BPStep extends AmigaStep {
-    internal var
-      soundTranspose : int;
+    internal var soundTranspose : int;
   }
 }

--- a/Flod Flash/src/neoart/flod/soundmon/BPVoice.as
+++ b/Flod Flash/src/neoart/flod/soundmon/BPVoice.as
@@ -19,40 +19,40 @@ package neoart.flod.soundmon {
   import neoart.flod.core.*;
 
   public final class BPVoice {
-    internal var
-      index        : int,
-      next         : BPVoice,
-      channel      : AmigaChannel,
-      enabled      : int,
-      restart      : int,
-      note         : int,
-      period       : int,
-      sample       : int,
-      samplePtr    : int,
-      sampleLen    : int,
-      synth        : int,
-      synthPtr     : int,
-      arpeggio     : int,
-      autoArpeggio : int,
-      autoSlide    : int,
-      vibrato      : int,
-      volume       : int,
-      volumeDef    : int,
-      adsrControl  : int,
-      adsrPtr      : int,
-      adsrCtr      : int,
-      lfoControl   : int,
-      lfoPtr       : int,
-      lfoCtr       : int,
-      egControl    : int,
-      egPtr        : int,
-      egCtr        : int,
-      egValue      : int,
-      fxControl    : int,
-      fxCtr        : int,
-      modControl   : int,
-      modPtr       : int,
-      modCtr       : int;
+    
+    internal var index        : int;
+    internal var next         : BPVoice;
+    internal var channel      : AmigaChannel;
+    internal var enabled      : int;
+    internal var restart      : int;
+    internal var note         : int;
+    internal var period       : int;
+    internal var sample       : int;
+    internal var samplePtr    : int;
+    internal var sampleLen    : int;
+    internal var synth        : int;
+    internal var synthPtr     : int;
+    internal var arpeggio     : int;
+    internal var autoArpeggio : int;
+    internal var autoSlide    : int;
+    internal var vibrato      : int;
+    internal var volume       : int;
+    internal var volumeDef    : int;
+    internal var adsrControl  : int;
+    internal var adsrPtr      : int;
+    internal var adsrCtr      : int;
+    internal var lfoControl   : int;
+    internal var lfoPtr       : int;
+    internal var lfoCtr       : int;
+    internal var egControl    : int;
+    internal var egPtr        : int;
+    internal var egCtr        : int;
+    internal var egValue      : int;
+    internal var fxControl    : int;
+    internal var fxCtr        : int;
+    internal var modControl   : int;
+    internal var modPtr       : int;
+    internal var modCtr       : int;
 
     public function BPVoice(index:int) {
       this.index = index;

--- a/Flod Flash/src/neoart/flod/trackers/HMPlayer.as
+++ b/Flod Flash/src/neoart/flod/trackers/HMPlayer.as
@@ -20,16 +20,16 @@ package neoart.flod.trackers {
   import neoart.flod.core.*;
 
   public final class HMPlayer extends AmigaPlayer {
-    private var
-      track      : Vector.<int>,
-      patterns   : Vector.<AmigaRow>,
-      samples    : Vector.<HMSample>,
-      length     : int,
-      restart    : int,
-      voices     : Vector.<HMVoice>,
-      trackPos   : int,
-      patternPos : int,
-      jumpFlag   : int;
+    
+    private var track      : Vector.<int>;
+    private var patterns   : Vector.<AmigaRow>;
+    private var samples    : Vector.<HMSample>;
+    private var length     : int;
+    private var restart    : int;
+    private var voices     : Vector.<HMVoice>;
+    private var trackPos   : int;
+    private var patternPos : int;
+    private var jumpFlag   : int;
 
     public function HMPlayer(amiga:Amiga = null) {
       super(amiga);
@@ -126,8 +126,11 @@ package neoart.flod.trackers {
             case 15:  //set speed
               value = voice.param;
 
-              if (value < 1) value = 1;
-                else if (value > 31) value = 31;
+              if (value < 1) {
+			  value = 1;}
+                else if (value > 31) {
+					value = 31;
+			  }
 
               speed = value;
               tick = 0;
@@ -250,7 +253,7 @@ package neoart.flod.trackers {
         } else {
           id = id.substr(0, 2);
           if (id == "El")
-            stream.position += 18;
+            {stream.position += 18;}
           else {
             stream.position -= 4;
             id = stream.readMultiByte(22, ENCODING);
@@ -335,8 +338,8 @@ package neoart.flod.trackers {
           case 0:   //arpeggio
             value = tick % 3;
             if (!value) break;
-            if (value == 1) value = voice.param >> 4;
-              else value = voice.param & 0x0f;
+            if (value == 1) {value = voice.param >> 4;}
+              else {value = voice.param & 0x0f;}
 
             len = 37 - value;
 
@@ -359,7 +362,7 @@ package neoart.flod.trackers {
             break;
           case 3:   //tone portamento
           case 5:   //tone portamento + volume slide
-            if (voice.effect == 5) slide = 1;
+            if (voice.effect == 5) {slide = 1;}
             else if (voice.param) {
               voice.portaSpeed = voice.param;
               voice.param = 0;
@@ -384,14 +387,14 @@ package neoart.flod.trackers {
             break;
           case 4:   //vibrato
           case 6:   //vibrato + volume slide;
-            if (voice.effect == 6) slide = 1;
-              else if (voice.param) voice.vibratoSpeed = voice.param;
+            if (voice.effect == 6) {slide = 1;}
+              else if (voice.param) {voice.vibratoSpeed = voice.param;}
 
             value = VIBRATO[int((voice.vibratoPos >> 2) & 31)];
             value = ((voice.vibratoSpeed & 0x0f) * value) >> 7;
 
-            if (voice.vibratoPos > 127) period -= value;
-              else period += value;
+            if (voice.vibratoPos > 127) {period -= value;}
+              else {period += value;}
 
             value = (voice.vibratoSpeed >> 2) & 60;
             voice.vibratoPos = (voice.vibratoPos + value) & 255;
@@ -416,11 +419,11 @@ package neoart.flod.trackers {
       if (slide) {
         value = voice.param >> 4;
 
-        if (value) voice.volume2 += value;
-          else voice.volume2 -= voice.param & 0x0f;
+        if (value) {voice.volume2 += value;}
+          else {voice.volume2 -= voice.param & 0x0f;}
 
-        if (voice.volume2 > 64) voice.volume2 = 64;
-          else if (voice.volume2 < 0) voice.volume2 = 0;
+        if (voice.volume2 > 64) {voice.volume2 = 64;}
+          else if (voice.volume2 < 0) {voice.volume2 = 0;}
       }
     }
 
@@ -439,8 +442,7 @@ package neoart.flod.trackers {
       voice.channel.volume = (voice.volume1 * voice.volume2) >> 6;
     }
 
-    private const
-      MEGARPEGGIO: Vector.<int> = Vector.<int>([
+    private const MEGARPEGGIO: Vector.<int> = Vector.<int>([
          0, 3, 7,12,15,12, 7, 3, 0, 3, 7,12,15,12, 7, 3,
          0, 4, 7,12,16,12, 7, 4, 0, 4, 7,12,16,12, 7, 4,
          0, 3, 8,12,15,12, 8, 3, 0, 3, 8,12,15,12, 8, 3,
@@ -456,14 +458,14 @@ package neoart.flod.trackers {
          0,12, 0,12, 0,12, 0,12, 0,12, 0,12, 0,12, 0,12,
          0,12,24,12, 0,12,24,12, 0,12,24,12, 0,12,24,12,
          0, 3, 0, 3, 0, 3, 0, 3, 0, 3, 0, 3, 0, 3, 0, 3,
-         0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4]),
+         0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4]);
 
-      PERIODS: Vector.<int> = Vector.<int>([
+    private const PERIODS: Vector.<int> = Vector.<int>([
         856,808,762,720,678,640,604,570,538,508,480,453,
         428,404,381,360,339,320,302,285,269,254,240,226,
-        214,202,190,180,170,160,151,143,135,127,120,113,0]),
+        214, 202, 190, 180, 170, 160, 151, 143, 135, 127, 120, 113, 0]);
 
-      VIBRATO: Vector.<int> = Vector.<int>([
+    private const VIBRATO: Vector.<int> = Vector.<int>([
           0, 24, 49, 74, 97,120,141,161,180,197,212,224,
         235,244,250,253,255,253,250,244,235,224,212,197,
         180,161,141,120, 97, 74, 49, 24]);

--- a/Flod Flash/src/neoart/flod/trackers/HMSample.as
+++ b/Flod Flash/src/neoart/flod/trackers/HMSample.as
@@ -19,11 +19,11 @@ package neoart.flod.trackers {
   import neoart.flod.core.*;
 
   public final class HMSample extends AmigaSample {
-    internal var
-      finetune : int,
-      restart  : int,
-      waveLen  : int,
-      waves    : Vector.<int>,
-      volumes  : Vector.<int>;
+    
+    internal var finetune : int;
+    internal var restart  : int;
+    internal var waveLen  : int;
+    internal var waves    : Vector.<int>;
+    internal var volumes  : Vector.<int>;
   }
 }

--- a/Flod Flash/src/neoart/flod/trackers/HMVoice.as
+++ b/Flod Flash/src/neoart/flod/trackers/HMVoice.as
@@ -19,24 +19,24 @@ package neoart.flod.trackers {
   import neoart.flod.core.*;
 
   public final class HMVoice {
-    internal var
-      index        : int,
-      next         : HMVoice,
-      channel      : AmigaChannel,
-      sample       : HMSample,
-      enabled      : int,
-      period       : int,
-      effect       : int,
-      param        : int,
-      volume1      : int,
-      volume2      : int,
-      handler      : int,
-      portaDir     : int,
-      portaPeriod  : int,
-      portaSpeed   : int,
-      vibratoPos   : int,
-      vibratoSpeed : int,
-      wavePos      : int;
+    
+    internal var index        : int;
+    internal var next         : HMVoice;
+    internal var channel      : AmigaChannel;
+    internal var sample       : HMSample;
+    internal var enabled      : int;
+    internal var period       : int;
+    internal var effect       : int;
+    internal var param        : int;
+    internal var volume1      : int;
+    internal var volume2      : int;
+    internal var handler      : int;
+    internal var portaDir     : int;
+    internal var portaPeriod  : int;
+    internal var portaSpeed   : int;
+    internal var vibratoPos   : int;
+    internal var vibratoSpeed : int;
+    internal var wavePos      : int;
 
     public function HMVoice(index:int) {
       this.index = index;

--- a/Flod Flash/src/neoart/flod/trackers/MKPlayer.as
+++ b/Flod Flash/src/neoart/flod/trackers/MKPlayer.as
@@ -20,18 +20,18 @@ package neoart.flod.trackers {
   import neoart.flod.core.*;
 
   public final class MKPlayer extends AmigaPlayer {
-    private var
-      track        : Vector.<int>,
-      patterns     : Vector.<AmigaRow>,
-      samples      : Vector.<AmigaSample>,
-      length       : int,
-      restart      : int,
-      voices       : Vector.<MKVoice>,
-      trackPos     : int,
-      patternPos   : int,
-      jumpFlag     : int,
-      vibratoDepth : int,
-      restartSave  : int;
+    
+    private var track        : Vector.<int>;
+    private var patterns     : Vector.<AmigaRow>;
+    private var samples      : Vector.<AmigaSample>;
+    private var length       : int;
+    private var restart      : int;
+    private var voices       : Vector.<MKVoice>;
+    private var trackPos     : int;
+    private var patternPos   : int;
+    private var jumpFlag     : int;
+    private var vibratoDepth : int;
+    private var restartSave  : int;
 
     public function MKPlayer(amiga:Amiga = null) {
       super(amiga);
@@ -50,14 +50,15 @@ package neoart.flod.trackers {
 
     override public function set force(value:int):void {
       if (value < SOUNDTRACKER_23)
-        value = SOUNDTRACKER_23;
+        {value = SOUNDTRACKER_23;}
       else if (value > NOISETRACKER_20)
-        value = NOISETRACKER_20;
+       { value = NOISETRACKER_20;}
 
+	   trace("force version" , value);
       version = value;
 
-      if (value == NOISETRACKER_20) vibratoDepth = 6;
-        else vibratoDepth = 7;
+      if (value == NOISETRACKER_20) {vibratoDepth = 6;}
+        else{ vibratoDepth = 7;}
 
       if (value == NOISETRACKER_10) {
         restartSave = restart;
@@ -131,8 +132,8 @@ package neoart.flod.trackers {
             case 15:  //set speed
               value = voice.param;
 
-              if (value < 1) value = 1;
-                else if (value > 31) value = 31;
+              if (value < 1) {value = 1;}
+                else if (value > 31) {value = 31;}
 
               speed = value;
               tick = 0;
@@ -165,8 +166,8 @@ package neoart.flod.trackers {
                 continue;
               }
 
-              if (value == 1) value = voice.param >> 4;
-                else value = voice.param & 0x0f;
+              if (value == 1) {value = voice.param >> 4;}
+                else {value = voice.param & 0x0f;}
 
               period = voice.period & 0x0fff;
               len = 37 - value;
@@ -227,8 +228,8 @@ package neoart.flod.trackers {
               value = (voice.vibratoPos >> 2) & 31;
               value = ((voice.vibratoSpeed & 0x0f) * VIBRATO[value]) >> vibratoDepth;
 
-              if (voice.vibratoPos > 127) chan.period = voice.period - value;
-                else chan.period = voice.period + value;
+              if (voice.vibratoPos > 127) {chan.period = voice.period - value;}
+                else {chan.period = voice.period + value;}
 
               value = (voice.vibratoSpeed >> 2) & 60;
               voice.vibratoPos = (voice.vibratoPos + value) & 255;
@@ -242,11 +243,11 @@ package neoart.flod.trackers {
             value = voice.param >> 4;
             slide = 0;
 
-            if (value) voice.volume += value;
-              else voice.volume -= voice.param & 0x0f;
+            if (value) {voice.volume += value;}
+              else {voice.volume -= voice.param & 0x0f;}
 
-            if (voice.volume < 0) voice.volume = 0;
-              else if (voice.volume > 64) voice.volume = 64;
+            if (voice.volume < 0) {voice.volume = 0;}
+              else if (voice.volume > 64) {voice.volume = 64;}
 
             chan.volume = voice.volume;
           }
@@ -365,6 +366,7 @@ package neoart.flod.trackers {
           version = NOISETRACKER_20;
 
         if (row.effect > 6 && row.effect < 10) {
+			trace(row.effect);
           version = 0;
           return;
         }
@@ -399,20 +401,20 @@ package neoart.flod.trackers {
         version = NOISETRACKER_11;
     }
 
-    public static const
-      SOUNDTRACKER_23 : int = 1,
-      SOUNDTRACKER_24 : int = 2,
-      NOISETRACKER_10 : int = 3,
-      NOISETRACKER_11 : int = 4,
-      NOISETRACKER_20 : int = 5;
+    
+    public static const SOUNDTRACKER_23 : int = 1;
+    public static const SOUNDTRACKER_24 : int = 2;
+    public static const NOISETRACKER_10 : int = 3;
+    public static const NOISETRACKER_11 : int = 4;
+    public static const NOISETRACKER_20 : int = 5;
 
-    private const
-      PERIODS: Vector.<int> = Vector.<int>([
+    
+    private const PERIODS: Vector.<int> = Vector.<int>([
         856,808,762,720,678,640,604,570,538,508,480,453,
         428,404,381,360,339,320,302,285,269,254,240,226,
-        214,202,190,180,170,160,151,143,135,127,120,113,0]),
+        214, 202, 190, 180, 170, 160, 151, 143, 135, 127, 120, 113, 0]);
 
-      VIBRATO: Vector.<int> = Vector.<int>([
+    private const VIBRATO: Vector.<int> = Vector.<int>([
           0, 24, 49, 74, 97,120,141,161,180,197,212,224,
         235,244,250,253,255,253,250,244,235,224,212,197,
         180,161,141,120, 97, 74, 49, 24]);

--- a/Flod Flash/src/neoart/flod/trackers/MKVoice.as
+++ b/Flod Flash/src/neoart/flod/trackers/MKVoice.as
@@ -19,21 +19,21 @@ package neoart.flod.trackers {
   import neoart.flod.core.*;
 
   public final class MKVoice {
-    internal var
-      index        : int,
-      next         : MKVoice,
-      channel      : AmigaChannel,
-      sample       : AmigaSample,
-      enabled      : int,
-      period       : int,
-      effect       : int,
-      param        : int,
-      volume       : int,
-      portaDir     : int,
-      portaPeriod  : int,
-      portaSpeed   : int,
-      vibratoPos   : int,
-      vibratoSpeed : int;
+    
+    internal var index        : int;
+    internal var next         : MKVoice;
+    internal var channel      : AmigaChannel;
+    internal var sample       : AmigaSample;
+    internal var enabled      : int;
+    internal var period       : int;
+    internal var effect       : int;
+    internal var param        : int;
+    internal var volume       : int;
+    internal var portaDir     : int;
+    internal var portaPeriod  : int;
+    internal var portaSpeed   : int;
+    internal var vibratoPos   : int;
+    internal var vibratoSpeed : int;
 
     public function MKVoice(index:int) {
       this.index = index;

--- a/Flod Flash/src/neoart/flod/trackers/PTPlayer.as
+++ b/Flod Flash/src/neoart/flod/trackers/PTPlayer.as
@@ -20,19 +20,19 @@ package neoart.flod.trackers {
   import neoart.flod.core.*;
 
   public final class PTPlayer extends AmigaPlayer {
-    private var
-      track        : Vector.<int>,
-      patterns     : Vector.<PTRow>,
-      samples      : Vector.<PTSample>,
-      length       : int,
-      voices       : Vector.<PTVoice>,
-      trackPos     : int,
-      patternPos   : int,
-      patternBreak : int,
-      patternDelay : int,
-      breakPos     : int,
-      jumpFlag     : int,
-      vibratoDepth : int;
+    
+    private var track        : Vector.<int>;
+    private var patterns     : Vector.<PTRow>;
+    private var samples      : Vector.<PTSample>;
+    private var length       : int;
+    private var voices       : Vector.<PTVoice>;
+    private var trackPos     : int;
+    private var patternPos   : int;
+    private var patternBreak : int;
+    private var patternDelay : int;
+    private var breakPos     : int;
+    private var jumpFlag     : int;
+    private var vibratoDepth : int;
 
     public function PTPlayer(amiga:Amiga = null) {
       super(amiga);
@@ -52,14 +52,14 @@ package neoart.flod.trackers {
 
     override public function set force(value:int):void {
       if (value < PROTRACKER_10)
-        value = PROTRACKER_10;
+        {value = PROTRACKER_10;}
       else if (value > PROTRACKER_12)
-        value = PROTRACKER_12;
+       { value = PROTRACKER_12;}
 
       version = value;
 
-      if (value < PROTRACKER_11) vibratoDepth = 6;
-        else vibratoDepth = 7;
+      if (value < PROTRACKER_11) {vibratoDepth = 6;}
+        else {vibratoDepth = 7;}
     }
 
     override public function process():void {
@@ -338,8 +338,8 @@ package neoart.flod.trackers {
               continue;
             }
 
-            if (value == 1) value = voice.param >> 4;
-              else value = voice.param & 0x0f;
+            if (value == 1) {value = voice.param >> 4;}
+              else {value = voice.param & 0x0f;}
 
             i = voice.finetune;
             position = i + 37;
@@ -419,8 +419,8 @@ package neoart.flod.trackers {
               position <<= 3;
 
               if (wave == 1) {
-                if (voice.vibratoPos > 127) value -= position;
-                  else value = position;
+                if (voice.vibratoPos > 127) {value -= position;}
+                  else {value = position;}
               }
             } else {
               value = VIBRATO[position];
@@ -428,8 +428,8 @@ package neoart.flod.trackers {
 
             value = ((voice.vibratoParam & 0x0f) * value) >> vibratoDepth;
 
-            if (voice.vibratoPos > 127) chan.period = voice.period - value;
-              else chan.period = voice.period + value;
+            if (voice.vibratoPos > 127) {chan.period = voice.period - value;}
+              else {chan.period = voice.period + value;}
 
             value = (voice.vibratoParam >> 2) & 60;
             voice.vibratoPos = (voice.vibratoPos + value) & 255;
@@ -452,8 +452,8 @@ package neoart.flod.trackers {
               position <<= 3;
 
               if (wave == 1) {
-                if (voice.tremoloPos > 127) value -= position;
-                  else value = position;
+                if (voice.tremoloPos > 127) {value -= position;}
+                  else {value = position;}
               }
             } else {
               value = VIBRATO[position];
@@ -461,8 +461,8 @@ package neoart.flod.trackers {
 
             value = ((voice.tremoloParam & 0x0f) * value) >> 6;
 
-            if (voice.tremoloPos > 127) chan.volume = voice.volume - value;
-              else chan.volume = voice.volume + value;
+            if (voice.tremoloPos > 127) {chan.volume = voice.volume - value;}
+              else{ chan.volume = voice.volume + value;}
 
             value = (voice.tremoloParam >> 2) & 60;
             voice.tremoloPos = (voice.tremoloPos + value) & 255;
@@ -479,11 +479,11 @@ package neoart.flod.trackers {
           slide = 0;
           value = voice.param >> 4;
 
-          if (value) voice.volume += value;
-            else voice.volume -= voice.param & 0x0f;
+          if (value) {voice.volume += value;}
+            else {voice.volume -= voice.param & 0x0f;}
 
-          if (voice.volume < 0) voice.volume = 0;
-            else if (voice.volume > 64) voice.volume = 64;
+          if (voice.volume < 0) {voice.volume = 0;}
+            else if (voice.volume > 64) {voice.volume = 64;}
 
           chan.volume = voice.volume;
         }
@@ -520,8 +520,8 @@ package neoart.flod.trackers {
         case 13:  //pattern break
           breakPos = ((voice.param >> 4) * 10) + (voice.param & 0x0f);
 
-          if (breakPos > 63) breakPos = 0;
-            else breakPos <<= 2;
+          if (breakPos > 63) {breakPos = 0;}
+            else {breakPos <<= 2;}
 
           jumpFlag = 1;
           break;
@@ -531,8 +531,8 @@ package neoart.flod.trackers {
         case 15:  //set speed
           if (!voice.param) return;
 
-          if (voice.param < 32) speed = voice.param;
-            else amiga.samplesTick = 110250 / voice.param;
+          if (voice.param < 32) {speed = voice.param;}
+            else {amiga.samplesTick = 110250 / voice.param;}
 
           tick = 0;
           break;
@@ -571,8 +571,8 @@ package neoart.flod.trackers {
           if (tick) return;
 
           if (param) {
-            if (voice.loopCtr) voice.loopCtr--;
-              else voice.loopCtr = param;
+            if (voice.loopCtr) {voice.loopCtr--;}
+              else {voice.loopCtr = param;}
 
             if (voice.loopCtr) {
               breakPos = voice.loopPos << 2;
@@ -674,13 +674,13 @@ package neoart.flod.trackers {
       }
     }
 
-    public static const
-      PROTRACKER_10 : int = 1,
-      PROTRACKER_11 : int = 2,
-      PROTRACKER_12 : int = 3;
+    
+    public static const PROTRACKER_10 : int = 1;
+    public static const PROTRACKER_11 : int = 2;
+    public static const PROTRACKER_12 : int = 3;
 
-    private const
-      PERIODS : Vector.<int> = Vector.<int>([
+    
+    private const PERIODS : Vector.<int> = Vector.<int>([
         856,808,762,720,678,640,604,570,538,508,480,453,
         428,404,381,360,339,320,302,285,269,254,240,226,
         214,202,190,180,170,160,151,143,135,127,120,113,0,
@@ -728,14 +728,14 @@ package neoart.flod.trackers {
         217,205,193,183,172,163,154,145,137,129,122,115,0,
         862,814,768,725,684,646,610,575,543,513,484,457,
         431,407,384,363,342,323,305,288,272,256,242,228,
-        216,203,192,181,171,161,152,144,136,128,121,114,0]),
+        216, 203, 192, 181, 171, 161, 152, 144, 136, 128, 121, 114, 0]);
 
-      VIBRATO: Vector.<int> = Vector.<int>([
+    private const VIBRATO: Vector.<int> = Vector.<int>([
           0, 24, 49, 74, 97,120,141,161,180,197,212,224,
         235,244,250,253,255,253,250,244,235,224,212,197,
-        180,161,141,120, 97, 74, 49, 24]),
+        180, 161, 141, 120, 97, 74, 49, 24]);
 
-      FUNKREP: Vector.<int> = Vector.<int>([
+    private const FUNKREP: Vector.<int> = Vector.<int>([
         0,5,6,7,8,10,11,13,16,19,22,26,32,43,64,128]);
   }
 }

--- a/Flod Flash/src/neoart/flod/trackers/PTRow.as
+++ b/Flod Flash/src/neoart/flod/trackers/PTRow.as
@@ -19,7 +19,6 @@ package neoart.flod.trackers {
   import neoart.flod.core.*;
 
   public final class PTRow extends AmigaRow {
-    internal var
-      step : int;
+    internal var step : int;
   }
 }

--- a/Flod Flash/src/neoart/flod/trackers/PTSample.as
+++ b/Flod Flash/src/neoart/flod/trackers/PTSample.as
@@ -19,8 +19,7 @@ package neoart.flod.trackers {
   import neoart.flod.core.*;
 
   public final class PTSample extends AmigaSample {
-    internal var
-      finetune : int,
-      realLen  : int;
+    internal var finetune : int;
+    internal var realLen  : int;
   }
 }

--- a/Flod Flash/src/neoart/flod/trackers/PTVoice.as
+++ b/Flod Flash/src/neoart/flod/trackers/PTVoice.as
@@ -19,38 +19,38 @@ package neoart.flod.trackers {
   import neoart.flod.core.*;
 
   public final class PTVoice {
-    internal var
-      index        : int,
-      next         : PTVoice,
-      channel      : AmigaChannel,
-      sample       : PTSample,
-      enabled      : int,
-      loopCtr      : int,
-      loopPos      : int,
-      step         : int,
-      period       : int,
-      effect       : int,
-      param        : int,
-      volume       : int,
-      pointer      : int,
-      length       : int,
-      loopPtr      : int,
-      repeat       : int,
-      finetune     : int,
-      offset       : int,
-      portaDir     : int,
-      portaPeriod  : int,
-      portaSpeed   : int,
-      glissando    : int,
-      tremoloParam : int,
-      tremoloPos   : int,
-      tremoloWave  : int,
-      vibratoParam : int,
-      vibratoPos   : int,
-      vibratoWave  : int,
-      funkPos      : int,
-      funkSpeed    : int,
-      funkWave     : int;
+    
+    internal var index        : int;
+    internal var next         : PTVoice;
+    internal var channel      : AmigaChannel;
+    internal var sample       : PTSample;
+    internal var enabled      : int;
+    internal var loopCtr      : int;
+    internal var loopPos      : int;
+    internal var step         : int;
+    internal var period       : int;
+    internal var effect       : int;
+    internal var param        : int;
+    internal var volume       : int;
+    internal var pointer      : int;
+    internal var length       : int;
+    internal var loopPtr      : int;
+    internal var repeat       : int;
+    internal var finetune     : int;
+    internal var offset       : int;
+    internal var portaDir     : int;
+    internal var portaPeriod  : int;
+    internal var portaSpeed   : int;
+    internal var glissando    : int;
+    internal var tremoloParam : int;
+    internal var tremoloPos   : int;
+    internal var tremoloWave  : int;
+    internal var vibratoParam : int;
+    internal var vibratoPos   : int;
+    internal var vibratoWave  : int;
+    internal var funkPos      : int;
+    internal var funkSpeed    : int;
+    internal var funkWave     : int;
 
     public function PTVoice(index:int) {
       this.index = index;

--- a/Flod Flash/src/neoart/flod/trackers/STPlayer.as
+++ b/Flod Flash/src/neoart/flod/trackers/STPlayer.as
@@ -20,15 +20,15 @@ package neoart.flod.trackers {
   import neoart.flod.core.*;
 
   public final class STPlayer extends AmigaPlayer {
-    private var
-      track      : Vector.<int>,
-      patterns   : Vector.<AmigaRow>,
-      samples    : Vector.<AmigaSample>,
-      length     : int,
-      voices     : Vector.<STVoice>,
-      trackPos   : int,
-      patternPos : int,
-      jumpFlag   : int;
+    
+    private var track      : Vector.<int>;
+    private var patterns   : Vector.<AmigaRow>;
+    private var samples    : Vector.<AmigaSample>;
+    private var length     : int;
+    private var voices     : Vector.<STVoice>;
+    private var trackPos   : int;
+    private var patternPos : int;
+    private var jumpFlag   : int;
 
     public function STPlayer(amiga:Amiga = null) {
       super(amiga);
@@ -46,9 +46,9 @@ package neoart.flod.trackers {
 
     override public function set force(value:int):void {
       if (value < ULTIMATE_SOUNDTRACKER)
-        value = ULTIMATE_SOUNDTRACKER;
+        {value = ULTIMATE_SOUNDTRACKER;}
       else if (value > DOC_SOUNDTRACKER_20)
-        value = DOC_SOUNDTRACKER_20;
+        {value = DOC_SOUNDTRACKER_20;}
 
       version = value;
     }
@@ -78,8 +78,8 @@ package neoart.flod.trackers {
           if (row.sample) {
             sample = voice.sample = samples[row.sample];
 
-            if (((version & 2) == 2) && voice.effect == 12) chan.volume = voice.param;
-              else chan.volume = sample.volume;
+            if (((version & 2) == 2) && voice.effect == 12) {chan.volume = voice.param;}
+              else {chan.volume = sample.volume;}
           } else {
             sample = voice.sample;
           }
@@ -138,8 +138,8 @@ package neoart.flod.trackers {
             } else if (voice.effect == 2) {
               value = voice.param >> 4;
 
-              if (value) voice.period += value;
-                else voice.period -= (voice.param & 0x0f);
+              if (value) {voice.period += value;}
+                else {voice.period -= (voice.param & 0x0f);}
 
               chan.period = voice.period;
             }
@@ -335,8 +335,8 @@ package neoart.flod.trackers {
         return;
       }
 
-      if (param == 1) param = voice.param >> 4;
-        else param = voice.param & 0x0f;
+      if (param == 1) {param = voice.param >> 4;}
+        else {param = voice.param & 0x0f;}
 
       while (voice.last != PERIODS[i]) i++;
       chan.period = PERIODS[int(i + param)];
@@ -353,14 +353,13 @@ package neoart.flod.trackers {
       return 1;
     }
 
-    public static const
-      ULTIMATE_SOUNDTRACKER : int = 1,
-      DOC_SOUNDTRACKER_9    : int = 2,
-      MASTER_SOUNDTRACKER   : int = 3,
-      DOC_SOUNDTRACKER_20   : int = 4;
+    
+    public static const ULTIMATE_SOUNDTRACKER : int = 1;
+    public static const DOC_SOUNDTRACKER_9    : int = 2;
+    public static const MASTER_SOUNDTRACKER   : int = 3;
+    public static const DOC_SOUNDTRACKER_20   : int = 4;
 
-    private const
-      PERIODS: Vector.<int> = Vector.<int>([
+    private const PERIODS: Vector.<int> = Vector.<int>([
         856,808,762,720,678,640,604,570,538,508,480,453,
         428,404,381,360,339,320,302,285,269,254,240,226,
         214,202,190,180,170,160,151,143,135,127,120,113,

--- a/Flod Flash/src/neoart/flod/trackers/STVoice.as
+++ b/Flod Flash/src/neoart/flod/trackers/STVoice.as
@@ -19,16 +19,16 @@ package neoart.flod.trackers {
   import neoart.flod.core.*;
 
   public final class STVoice {
-    internal var
-      index   : int,
-      next    : STVoice,
-      channel : AmigaChannel,
-      sample  : AmigaSample,
-      enabled : int,
-      period  : int,
-      last    : int,
-      effect  : int,
-      param   : int;
+    
+    internal var index   : int;
+    internal var next    : STVoice;
+    internal var channel : AmigaChannel;
+    internal var sample  : AmigaSample;
+    internal var enabled : int;
+    internal var period  : int;
+    internal var last    : int;
+    internal var effect  : int;
+    internal var param   : int;
 
     public function STVoice(index:int) {
       this.index = index;

--- a/Flod Flash/src/neoart/flod/whittaker/DWPlayer.as
+++ b/Flod Flash/src/neoart/flod/whittaker/DWPlayer.as
@@ -20,41 +20,41 @@ package neoart.flod.whittaker {
   import neoart.flod.core.*;
 
   public final class DWPlayer extends AmigaPlayer {
-    private var
-      songs         : Vector.<DWSong>,
-      samples       : Vector.<DWSample>,
-      stream        : ByteArray,
-      song          : DWSong,
-      songvol       : int,
-      master        : int,
-      periods       : int,
-      frqseqs       : int,
-      volseqs       : int,
-      transpose     : int,
-      slower        : int,
-      slowerCounter : int,
-      delaySpeed    : int,
-      delayCounter  : int,
-      fadeSpeed     : int,
-      fadeCounter   : int,
-      wave          : DWSample,
-      waveCenter    : int,
-      waveLo        : int,
-      waveHi        : int,
-      waveDir       : int,
-      waveLen       : int,
-      wavePos       : int,
-      waveRateNeg   : int,
-      waveRatePos   : int,
-      voices        : Vector.<DWVoice>,
-      active        : int,
-      complete      : int,
-      base          : int,
-      com2          : int,
-      com3          : int,
-      com4          : int,
-      readMix       : String,
-      readLen       : int;
+    
+    private var songs         : Vector.<DWSong>;
+    private var samples       : Vector.<DWSample>;
+    private var stream        : ByteArray;
+    private var song          : DWSong;
+    private var songvol       : int;
+    private var master        : int;
+    private var periods       : int;
+    private var frqseqs       : int;
+    private var volseqs       : int;
+    private var transpose     : int;
+    private var slower        : int;
+    private var slowerCounter : int;
+    private var delaySpeed    : int;
+    private var delayCounter  : int;
+    private var fadeSpeed     : int;
+    private var fadeCounter   : int;
+    private var wave          : DWSample;
+    private var waveCenter    : int;
+    private var waveLo        : int;
+    private var waveHi        : int;
+    private var waveDir       : int;
+    private var waveLen       : int;
+    private var wavePos       : int;
+    private var waveRateNeg   : int;
+    private var waveRatePos   : int;
+    private var voices        : Vector.<DWVoice>;
+    private var active        : int;
+    private var complete      : int;
+    private var base          : int;
+    private var com2          : int;
+    private var com3          : int;
+    private var com4          : int;
+    private var readMix       : String;
+    private var readLen       : int;
 
     public function DWPlayer(amiga:Amiga = null) {
       super(amiga);
@@ -160,8 +160,9 @@ package neoart.flod.whittaker {
                 stream.position = pos;
               } else {
                 switch (value) {
+                   
                   case -128:
-                    stream.position = voice.trackPtr + voice.trackPos;
+					stream.position = voice.trackPtr + voice.trackPos;
                     value = stream[readMix]();
 
                     if (value) {
@@ -169,7 +170,7 @@ package neoart.flod.whittaker {
                       voice.trackPos += readLen;
                     } else {
                       stream.position = voice.trackPtr;
-                      stream.position = base + stream[readMix]();
+                      stream.position = base + stream[readMix]() as uint;
                       voice.trackPos = readLen;
 
                       if (!loopSong) {
@@ -407,7 +408,7 @@ package neoart.flod.whittaker {
         voice.trackPtr   = song.tracks[voice.index];
         voice.trackPos   = readLen;
         stream.position  = voice.trackPtr;
-        voice.patternPos = base + stream[readMix]();
+        voice.patternPos = base + stream[readMix]() as uint;
 
         if (frqseqs) {
           stream.position = frqseqs;
@@ -508,7 +509,7 @@ package neoart.flod.whittaker {
         if (song.speed > 255) break;
 
         for (i = 0; i < channels; ++i) {
-          value = base + stream[readMix]();
+          value = base + stream[readMix]() as uint;
           if (value < lower) lower = value;
           song.tracks[i] = value;
         }
@@ -741,6 +742,7 @@ package neoart.flod.whittaker {
             break;
           case 0x4ef3:                                                          //jmp (a3,a2.w)
             stream.position += 2;
+			break;
           case 0x4ed2:                                                          //jmp a2
             lower = stream.position;
             stream.position -= 10;

--- a/Flod Flash/src/neoart/flod/whittaker/DWSample.as
+++ b/Flod Flash/src/neoart/flod/whittaker/DWSample.as
@@ -19,8 +19,7 @@ package neoart.flod.whittaker {
   import neoart.flod.core.*;
 
   public final class DWSample extends AmigaSample {
-    internal var
-      relative : int,
-      finetune : int;
+    internal var relative : int;
+    internal var finetune : int;
   }
 }

--- a/Flod Flash/src/neoart/flod/whittaker/DWSong.as
+++ b/Flod Flash/src/neoart/flod/whittaker/DWSong.as
@@ -18,9 +18,8 @@
 package neoart.flod.whittaker {
 
   public final class DWSong {
-    internal var
-      speed  : int,
-      delay  : int,
-      tracks : Vector.<int>;
+    internal var speed  : int;
+    internal var delay  : int;
+    internal var tracks : Vector.<int>;
   }
 }

--- a/Flod Flash/src/neoart/flod/whittaker/DWVoice.as
+++ b/Flod Flash/src/neoart/flod/whittaker/DWVoice.as
@@ -19,36 +19,36 @@ package neoart.flod.whittaker {
   import neoart.flod.core.*;
 
   public final class DWVoice {
-    internal var
-      index         : int,
-      bitFlag       : int,
-      next          : DWVoice,
-      channel       : AmigaChannel,
-      sample        : DWSample,
-      trackPtr      : int,
-      trackPos      : int,
-      patternPos    : int,
-      frqseqPtr     : int,
-      frqseqPos     : int,
-      volseqPtr     : int,
-      volseqPos     : int,
-      volseqSpeed   : int,
-      volseqCounter : int,
-      halve         : int,
-      speed         : int,
-      tick          : int,
-      busy          : int,
-      flags         : int,
-      note          : int,
-      period        : int,
-      transpose     : int,
-      portaDelay    : int,
-      portaDelta    : int,
-      portaSpeed    : int,
-      vibrato       : int,
-      vibratoDelta  : int,
-      vibratoSpeed  : int,
-      vibratoDepth  : int;
+    
+    internal var index         : int;
+    internal var bitFlag       : int;
+    internal var next          : DWVoice;
+    internal var channel       : AmigaChannel;
+    internal var sample        : DWSample;
+    internal var trackPtr      : int;
+    internal var trackPos      : int;
+    internal var patternPos    : int;
+    internal var frqseqPtr     : int;
+    internal var frqseqPos     : int;
+    internal var volseqPtr     : int;
+    internal var volseqPos     : int;
+    internal var volseqSpeed   : int;
+    internal var volseqCounter : int;
+    internal var halve         : int;
+    internal var speed         : int;
+    internal var tick          : int;
+    internal var busy          : int;
+    internal var flags         : int;
+    internal var note          : int;
+    internal var period        : int;
+    internal var transpose     : int;
+    internal var portaDelay    : int;
+    internal var portaDelta    : int;
+    internal var portaSpeed    : int;
+    internal var vibrato       : int;
+    internal var vibratoDelta  : int;
+    internal var vibratoSpeed  : int;
+    internal var vibratoDepth  : int;
 
     public function DWVoice(index:int, bitFlag:int) {
       this.index = index;


### PR DESCRIPTION
Changed made to the Flod 4.1 AS3 package to name it exportable with ax3. Mostly removing multiple var statements in classes and adding extra brackets to if/else statements that ax3 was struggling with and a couple spots where semicolons where missing from line ends. Also a spot fix to some 0 padded integers that where confusing ax3 in D1Player.